### PR TITLE
[feat] - 커뮤니티 목록, 인기글, 검색 조회 기능

### DIFF
--- a/src/main/java/com/team05/linkup/LinkupApplication.java
+++ b/src/main/java/com/team05/linkup/LinkupApplication.java
@@ -3,9 +3,11 @@ package com.team05.linkup;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableSpringDataWebSupport(pageSerializationMode = EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO)
 public class LinkupApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/team05/linkup/domain/community/api/CommunityController.java
+++ b/src/main/java/com/team05/linkup/domain/community/api/CommunityController.java
@@ -67,4 +67,23 @@ public class CommunityController {
         return ResponseEntity.ok(ApiResponse.success(popularCommunities));
     }
 
+    /**
+     * 키워드를 사용하여 커뮤니티 게시글을 검색합니다.
+     * 제목, 내용, 태그에서 키워드가 포함된 게시글 목록을 페이징하여 반환합니다.
+     *
+     * @param keyword 검색할 키워드 (필수).
+     * @param pageable 페이징 및 정렬 정보 (선택 사항, 기본값 적용됨).
+     * @return ResponseEntity containing an ApiResponse with a Page of CommunitySummaryResponse DTOs.
+     * Example URL: GET /v1/community/more-detail?keyword=spring
+     */
+    @GetMapping("/more-detail")
+    public ResponseEntity<ApiResponse<Page<CommunitySummaryResponse>>> searchCommunityList(
+            @RequestParam String keyword, // 검색어는 필수로 받음
+            // PageableDefault는 /list 와 동일하게 유지하거나 검색 결과에 맞게 조정
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        Page<CommunitySummaryResponse> searchResultPage = communityService.searchCommunities(keyword, pageable);
+        return ResponseEntity.ok(ApiResponse.success(searchResultPage));
+    }
+
 }

--- a/src/main/java/com/team05/linkup/domain/community/api/CommunityController.java
+++ b/src/main/java/com/team05/linkup/domain/community/api/CommunityController.java
@@ -1,0 +1,70 @@
+package com.team05.linkup.domain.community.api;
+
+
+import com.team05.linkup.common.dto.ApiResponse;
+import com.team05.linkup.domain.community.domain.CommunityCategory;
+import com.team05.linkup.domain.community.application.CommunityService;
+import com.team05.linkup.domain.community.dto.CommunitySummaryResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+
+/**
+ * community 관련 HTTP 요청을 처리하기 위한 Rest Controller.
+ * community 게시물을 목록에 대한 엔드 포인트를 제공 (Paginated, 필터링, 정렬)
+ * 그리고 인기있는 게시물을 검색
+ */
+@RestController
+@RequestMapping("/v1/community")
+@RequiredArgsConstructor
+public class CommunityController {
+
+    private final CommunityService communityService;
+    // private final CommentService commentService; // 댓글 관련 기능 필요 시 주입
+
+    /**
+     * 카테고리별로 필터링된(선택) 커뮤니티 게시물의 페이지별 목록을 검색합니다.
+     * pagable 매개 변수를 통해 정렬 지원
+     *
+     * @param category 옵션 범주를 필터링 할 수 있습니다.
+     * @param pageable 페이지 번호, 크기 및 정렬 순서를 포함하는 pagable 객체.
+     * Defaults : size = 5, sort = createat, direction = desc.
+     * @return ResponseEntity CommunitySummaryResponse DTO의 페이지가 포함된 ApiResponse를 포함합니다.
+     * 예제 URL : GET /v1/community/list?category=INFO&sort=viewCount,desc
+     */
+    @GetMapping("/list")
+    public ResponseEntity<ApiResponse<Page<CommunitySummaryResponse>>> getCommunityList(
+            @RequestParam(required = false) CommunityCategory category, // Enum으로 직접 받기
+            @PageableDefault(size = 5, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        Page<CommunitySummaryResponse> communityPage = communityService.findCommunities(category , pageable);
+        return ResponseEntity.ok(ApiResponse.success(communityPage));
+    }
+
+    /**
+     * 최근 활동을 기준으로 인기 커뮤니티 게시물 목록을 검색
+     * 인기도는 일반적으로 특정 기간의 조회수, 좋아요 수, 작성일을 기준으로 결정
+     *
+     * @param limit 반환할 인기 게시물의 최대 개수(기본값: 3개).
+     * @param day 인기도를 평가할 지난 일 수(기본값: 7개).
+     * @return CommunitySummaryResponse DTO 목록을 포함하는 ApiResponse를 포함하는 ResponseEntity.
+     * URL 예시: GET /v1/community/popular?limit=5&day=14
+     */
+    @GetMapping("/popular")
+    public ResponseEntity<ApiResponse<List<CommunitySummaryResponse>>> getPopularCommunities(
+             @RequestParam(defaultValue = "3") int limit,
+             @RequestParam(defaultValue = "7") int day) {
+
+        List<CommunitySummaryResponse> popularCommunities = communityService.findPopularCommunities(limit, day);
+
+        return ResponseEntity.ok(ApiResponse.success(popularCommunities));
+    }
+
+}

--- a/src/main/java/com/team05/linkup/domain/community/application/CommunityService.java
+++ b/src/main/java/com/team05/linkup/domain/community/application/CommunityService.java
@@ -48,13 +48,13 @@ public class CommunityService {
     }
 
     /**
-     * 최근 일정 기간 동안 작성된 게시글 중 인기 게시글 목록을 조회합니다.
-     * 인기도는 Repository 쿼리 내의 정렬 기준(조회수, 좋아요 수, 최신순)에 따라 결정됩니다.
-     * 이 메소드는 읽기 전용 트랜잭션으로 실행됩니다.
+     * 최근 일정 기간 동안 작성된 게시글 중 인기 게시글 목록을 조회
+     * 인기도는 Repository 쿼리 내의 정렬 기준(조회수, 좋아요 수, 최신순)에 따라 결정
+     * 이 메소드는 읽기 전용 트랜잭션으로 실행
      *
      * @param limit 조회할 최대 인기 게시글 수.
-     * @param day   인기 게시글을 선정할 최근 기간(일 단위). 예를 들어 7이면 최근 7일간의 게시글을 대상으로 합니다.
-     * @return 인기 게시글 요약 정보({@link CommunitySummaryResponse})의 {@link List}. 결과는 'limit' 수만큼 제한되며, 없을 경우 빈 리스트가 반환됩니다.
+     * @param day   인기 게시글을 선정할 최근 기간(일 단위). 예를 들어 7이면 최근 7일간의 게시글을 대상으로 함
+     * @return 인기 게시글 요약 정보({@link CommunitySummaryResponse})의 {@link List}. 결과는 'limit' 수만큼 제한되며, 없을 경우 빈 리스트가 반환
      * @see CommunityRepository#findPopularSince(ZonedDateTime, Pageable)
      */
     public List<CommunitySummaryResponse> findPopularCommunities(int limit, int day) {
@@ -67,6 +67,21 @@ public class CommunityService {
 
         // 3. Repository 메소드 호출
         return communityRepository.findPopularSince(daysAgo, topLimit);
+    }
+
+    /**
+     * 키워드를 사용하여 커뮤니티 게시글을 검색
+     * Repository 계층에 검색 로직을 위임
+     *
+     * @param keyword 검색 키워드.
+     * @param pageable 페이징 및 정렬 정보.
+     * @return 검색된 게시글 요약 정보 Page 객체.
+     */
+    public Page<CommunitySummaryResponse> searchCommunities(String keyword, Pageable pageable) {
+        if (keyword == null || keyword.isBlank()) {
+            return Page.empty(pageable);
+        }
+        return communityRepository.searchSummariesByKeyword(keyword, pageable);
     }
 
 }

--- a/src/main/java/com/team05/linkup/domain/community/application/CommunityService.java
+++ b/src/main/java/com/team05/linkup/domain/community/application/CommunityService.java
@@ -1,0 +1,72 @@
+
+package com.team05.linkup.domain.community.application;
+
+import com.team05.linkup.domain.community.domain.CommunityCategory;
+import com.team05.linkup.domain.community.infra.CommunityRepository;
+import com.team05.linkup.domain.community.dto.CommunitySummaryResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional; // 중요: 읽기 전용이므로 readOnly=true
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+
+/**
+ * 커뮤니티 게시글 관련 비즈니스 로직을 처리하는 애플리케이션 서비스 클래스입니다.
+ * 주로 조회(read) 작업을 수행하며, 클래스 레벨에 @Transactional(readOnly = true)이 적용되어 있습니다.
+ * {@link CommunityRepository}를 사용하여 데이터베이스와 상호작용합니다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommunityService {
+
+    private final CommunityRepository communityRepository;
+    // private final CommentRepository commentRepository; // 댓글 수 필요 시 주입
+    // private final LikeRepository likeRepository; // 좋아요 수 실시간 반영 필요 시 주입
+
+    /**
+     * 지정된 조건(카테고리 필터링, 페이징, 정렬)에 맞는 게시글 요약 목록을 조회합니다.
+     * 이 메소드는 읽기 전용 트랜잭션으로 실행됩니다.
+     *
+     * @param category 조회할 게시글 카테고리 (선택 사항, null일 경우 전체 카테고리 조회).
+     * @param pageable 페이징 및 정렬 정보 (페이지 번호, 페이지 크기, 정렬 기준). Spring Data Web Support에 의해 Controller에서 생성됩니다.
+     * @return 조건에 맞는 게시글 요약 정보({@link CommunitySummaryResponse})를 담고 있는 {@link Page} 객체.
+     * 결과가 없을 경우 빈 Page 객체가 반환됩니다.
+     * @see CommunityRepository#findCommunitySummaries(CommunityCategory, Pageable)
+     */
+    public Page<CommunitySummaryResponse> findCommunities(CommunityCategory category, Pageable pageable) {
+
+        return communityRepository.findCommunitySummaries(
+                category,
+                pageable
+        );
+    }
+
+    /**
+     * 최근 일정 기간 동안 작성된 게시글 중 인기 게시글 목록을 조회합니다.
+     * 인기도는 Repository 쿼리 내의 정렬 기준(조회수, 좋아요 수, 최신순)에 따라 결정됩니다.
+     * 이 메소드는 읽기 전용 트랜잭션으로 실행됩니다.
+     *
+     * @param limit 조회할 최대 인기 게시글 수.
+     * @param day   인기 게시글을 선정할 최근 기간(일 단위). 예를 들어 7이면 최근 7일간의 게시글을 대상으로 합니다.
+     * @return 인기 게시글 요약 정보({@link CommunitySummaryResponse})의 {@link List}. 결과는 'limit' 수만큼 제한되며, 없을 경우 빈 리스트가 반환됩니다.
+     * @see CommunityRepository#findPopularSince(ZonedDateTime, Pageable)
+     */
+    public List<CommunitySummaryResponse> findPopularCommunities(int limit, int day) {
+
+        // 1. 조회 시작 시점 계산
+        ZonedDateTime daysAgo = ZonedDateTime.now().minusDays(day);
+
+        // 2. 결과 개수 제한 설정
+        Pageable topLimit = PageRequest.of(0, limit);
+
+        // 3. Repository 메소드 호출
+        return communityRepository.findPopularSince(daysAgo, topLimit);
+    }
+
+}

--- a/src/main/java/com/team05/linkup/domain/community/domain/Comment.java
+++ b/src/main/java/com/team05/linkup/domain/community/domain/Comment.java
@@ -1,0 +1,54 @@
+// --- Comment Entity ---
+package com.team05.linkup.domain.community.domain;
+
+import com.team05.linkup.domain.baseEntity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+
+/**
+* 커뮤니티 기능에서 comment entity
+ * comment는 community(게시글) 및 잠재적으로 parent comment(답글)과 관련 될 수 있습니다.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "comments")
+public class Comment extends BaseEntity {
+
+    @Id
+    @Column(length = 36)
+    private String id;
+
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "user_id", nullable = false)
+//    private User user;
+    @Column(name = "user_id", nullable = false)
+    private String userId;
+
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "community_id", nullable = false)
+//    private Community community;
+    @Column(name = "community_id", nullable = false)
+    private String communityId;
+
+    @Column(nullable = false, length = 300)
+    private String commentContent;
+
+    @Column(name = "order_number") // For sorting replies if needed
+    private Long orderNumber;
+
+    @Column(name = "total_like_count", columnDefinition = "INT default 0")
+    private int totalLikeCount = 0;
+
+    @Column(length = 100) // Denormalized user name for easy retrieval
+    private String name;
+
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "parent_comment_id")
+//    private Comment parentComment;
+    @Column(name = "parent_comment_id")
+    private String parentCommentId;
+
+
+}

--- a/src/main/java/com/team05/linkup/domain/community/domain/Community.java
+++ b/src/main/java/com/team05/linkup/domain/community/domain/Community.java
@@ -1,0 +1,42 @@
+package com.team05.linkup.domain.community.domain;
+
+import com.team05.linkup.domain.baseEntity.BaseEntity;
+import com.team05.linkup.domain.user.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "community")
+public class Community extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    private CommunityCategory category;
+
+    @Column(name = "community_tag")
+    private String communityTag;
+
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    @Column(name = "view_count", nullable = false, columnDefinition = "BIGINT default 0")
+    private Long viewCount = 0L;
+
+    @Column(name = "like_count", nullable = false, columnDefinition = "BIGINT default 0")
+    private Long likeCount = 0L;
+
+}
+

--- a/src/main/java/com/team05/linkup/domain/community/domain/CommunityCategory.java
+++ b/src/main/java/com/team05/linkup/domain/community/domain/CommunityCategory.java
@@ -1,0 +1,14 @@
+package com.team05.linkup.domain.community.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommunityCategory {
+    QUESTION, // ("질문/답변"), // Keep korean names if needed for display elsewhere
+    INFO,     // ("정보공유"),
+    REVIEW,   // ("후기"),
+    FREE,     // ("자유게시판"),
+    TALENT;   // ("재능나눔");
+}

--- a/src/main/java/com/team05/linkup/domain/community/dto/CommunitySummaryResponse.java
+++ b/src/main/java/com/team05/linkup/domain/community/dto/CommunitySummaryResponse.java
@@ -1,0 +1,30 @@
+package com.team05.linkup.domain.community.dto;
+
+import com.team05.linkup.domain.community.domain.CommunityCategory;
+import java.time.ZonedDateTime;
+
+/**
+ * 커뮤니티 게시물의 요약 뷰를 나타내는 데이터 전송 객체(DTO).
+ * 커뮤니티 엔터티의 모든 세부 정보가 필요하지 않은 목록 뷰에 사용됩니다.
+ * 작성자의 별명, 댓글 수와 같은 계산된 데이터 또는 관련 데이터가 포함됩니다.
+ *
+ * @param id 커뮤니티 게시물의 고유 ID.
+ * @param nickname 게시물을 만든 사용자의 별명.
+ * @param title 커뮤니티 게시물의 제목.
+ * @param category 커뮤니티 게시물의 카테고리.
+ * @param createdAt 게시물이 작성된 날짜 및 시간.
+ * @param viewCount 게시물이 받은 조회수.
+ * @param likeCount 게시물이 받은 좋아요 수.
+ * @param commentCount 게시물과 연결된 총 댓글 수.
+ */
+public record CommunitySummaryResponse(
+        String id,
+        String nickname,
+        String title,
+        CommunityCategory category,
+        ZonedDateTime createdAt,
+        Long viewCount,
+        Long likeCount,
+        Long commentCount
+) {
+}

--- a/src/main/java/com/team05/linkup/domain/community/infra/CommunityRepository.java
+++ b/src/main/java/com/team05/linkup/domain/community/infra/CommunityRepository.java
@@ -61,4 +61,25 @@ public interface CommunityRepository extends JpaRepository<Community, String> {
     List<CommunitySummaryResponse> findPopularSince(@Param("startDate") ZonedDateTime startDate, Pageable pageable);
 
 
+    /**
+     * 키워드를 사용하여 제목, 내용, 태그에서 게시글을 검색하고 요약 정보를 반환합니다.
+     * 대소문자를 구분하지 않고 검색합니다.
+     *
+     * 경고: 이 쿼리는 데이터 양 증가 시 심각한 성능 저하를 유발할 수 있습니다.
+     * (특히 title, content, communityTag 컬럼에 인덱스가 없거나 활용되지 못할 경우)
+     * 향후 Full-Text Search 또는 검색 엔진 도입을 강력히 권장합니다.
+     *
+     * @param keyword 검색할 키워드 문자열.
+     * @param pageable 페이징 및 정렬 정보.
+     * @return 검색 조건에 맞는 게시글 요약 정보(CommunitySummaryResponse)를 담고 있는 Page 객체.
+     */
+    @Query("SELECT new com.team05.linkup.domain.community.dto.CommunitySummaryResponse(" +
+            "c.id, u.nickname, c.title, c.category, c.createdAt, c.viewCount, c.likeCount, " +
+            "(SELECT COUNT(cmt.id) FROM Comment cmt WHERE cmt.communityId = c.id)) " +
+            "FROM Community c JOIN c.user u " +
+            "WHERE c.title LIKE CONCAT('%', :keyword, '%') " +
+            "   OR c.content LIKE CONCAT('%', :keyword, '%') " +
+            "   OR c.communityTag LIKE CONCAT('%', :keyword, '%')")
+    Page<CommunitySummaryResponse> searchSummariesByKeyword(@Param("keyword") String keyword, Pageable pageable);
+
 }

--- a/src/main/java/com/team05/linkup/domain/community/infra/CommunityRepository.java
+++ b/src/main/java/com/team05/linkup/domain/community/infra/CommunityRepository.java
@@ -1,0 +1,64 @@
+package com.team05.linkup.domain.community.infra;
+
+import com.team05.linkup.domain.community.domain.Community;
+import com.team05.linkup.domain.community.domain.CommunityCategory;
+import com.team05.linkup.domain.community.dto.CommunitySummaryResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+
+/**
+ * {@link Community} 엔티티를 위한 Spring Data JPA 저장소입니다.
+ * 커뮤니티 데이터 접근을 위한 CRUD 작업 및 사용자 정의 쿼리를 제공합니다.
+ */
+public interface CommunityRepository extends JpaRepository<Community, String> {
+    /**
+     * 커뮤니티 요약의 페이지 매김된 목록을 찾습니다. 선택적으로 카테고리별로 필터링할 수 있으며,
+     * 작성자 닉네임과 각 게시물의 댓글 수를 포함
+     *
+     * 참고: 하위 쿼리 조건 'cmt.communityId = c.id'는 Comment 엔터티가
+     * 직접 'communityId' 필드를 사용한다고 가정합니다. Comment가 @ManyToOne 'community' 필드를 사용하는 경우,
+     * 조건을 'cmt.community = c'로 변경합니다.
+     *
+     * @param category 필터링 기준 카테고리(선택 사항, null일 수 있음).
+     * @param pageable 페이지 매김 및 정렬 정보.
+     * @return CommunitySummaryResponse DTO 페이지.
+     */
+    @Query("SELECT new com.team05.linkup.domain.community.dto.CommunitySummaryResponse(" +
+            "c.id, u.nickname, c.title, c.category, c.createdAt, c.viewCount, c.likeCount, " +
+            "(SELECT COUNT(cmt.id) FROM Comment cmt WHERE cmt.communityId = c.id)) " +
+            "FROM Community c JOIN c.user u " +
+            "WHERE (:category IS NULL OR c.category = :category)")
+    Page<CommunitySummaryResponse> findCommunitySummaries(
+            @Param("category") CommunityCategory category,
+            Pageable pageable);
+
+    /**
+     * 지정된 시작일 이후 생성된 인기 커뮤니티 요약 목록을 찾습니다.
+     * 조회수, 좋아요 수, 생성일 순으로 정렬합니다.
+     * 작성자 닉네임과 각 게시물의 댓글 수를 포함합니다.
+     *
+     * 참고: 하위 쿼리 조건 'cmt.communityId = c.id'는 Comment 엔터티가
+     * 직접 'communityId' 필드를 사용한다고 가정합니다. Comment가 @ManyToOne 'community' 필드를 사용하는 경우
+     * 조건을 'cmt.community = c'로 변경합니다.
+     *
+     * @param startDate 게시물이 생성되어야 하는 날짜입니다.
+     * @param pageable 페이지 매김 정보(주로 여기서는 결과를 제한하는 데 사용됨).
+     * @return 인기 CommunitySummaryResponse DTO 목록입니다.
+     */
+    @Query("SELECT new com.team05.linkup.domain.community.dto.CommunitySummaryResponse(" +
+            "c.id, u.nickname, c.title, c.category, c.createdAt, c.viewCount, c.likeCount, " +
+            "(SELECT COUNT(cmt.id) FROM Comment cmt WHERE cmt.communityId = c.id)) " +
+            "FROM Community c JOIN c.user u " + // User 정보 필요 시 JOIN
+            "WHERE c.createdAt > :startDate " +
+            "ORDER BY c.viewCount DESC, c.likeCount DESC, c.createdAt DESC")
+    List<CommunitySummaryResponse> findPopularSince(@Param("startDate") ZonedDateTime startDate, Pageable pageable);
+
+
+}


### PR DESCRIPTION
## ✨ PR 종류

- [X] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 🛠️ 작업 요약
![스크린샷 2025-04-30 185600](https://github.com/user-attachments/assets/f5a40902-a20a-460d-b1ec-3612a63cd757)
![스크린샷 2025-04-30 185544](https://github.com/user-attachments/assets/c5ef8f3f-b376-4661-b6d2-b2d62c47764e)

- 커뮤니티 게시글 조회 관련 API, Service, Repository, Entity, DTO 구현
- 기능: 카테고리별/전체 목록 조회 (페이징, 정렬), 인기 게시글 조회, 키워드 검색 기능 추가

## 📝 작업 상세

- **`CommunityController`**:
    - `/v1/community/list`: 카테고리 필터링 및 페이징/정렬 가능한 게시글 목록 조회 API 추가.
    - `/v1/community/popular`: 지정된 기간 내 인기 게시글 목록 조회 API 추가 (limit, day 파라미터).
    - `/v1/community/more-detail`: 키워드를 이용한 게시글 검색 API 추가 (페이징, 정렬).
- **`CommunityService`**:
    - `findCommunities`: Controller 요청을 받아 Repository의 목록 조회 메소드 호출.
    - `findPopularCommunities`: 기간 계산 및 Repository의 인기 게시글 조회 메소드 호출.
    - `searchCommunities`: Controller 요청을 받아 Repository의 키워드 검색 메소드 호출 (null/blank 체크 포함).
    - 클래스 레벨 `@Transactional(readOnly = true)` 적용으로 조회 성능 최적화.
- **`Community`, `Comment` Entities**:
    - 게시글(`Community`) 및 댓글(`Comment`) 엔티티 정의.
    - `Community`는 `User`와 Lazy Loading 관계 설정.
    - `Comment`는 `User`, `Community`, `parentComment` 관계를 직접 ID (`String`) 필드로 관리 (주석 처리된 `@ManyToOne` 참고).
- **`CommunityCategory` Enum**:
    - 게시글 카테고리 Enum 정의 (QUESTION, INFO, REVIEW, FREE, TALENT).
- **`CommunitySummaryResponse` DTO**:
    - 목록/검색 결과에 필요한 요약 정보 (`id`, `nickname`, `title`, `category`, `createdAt`, `viewCount`, `likeCount`, `commentCount`)를 담는 Record DTO 정의.
- **`CommunityRepository`**:
    - `findCommunitySummaries`: 카테고리 필터링, 페이징/정렬 지원, JPQL Constructor Expression 및 댓글 수 서브쿼리 사용.
    - `findPopularSince`: 지정된 날짜 이후 게시글 대상, 조회수/좋아요/최신순 정렬, JPQL Constructor Expression 및 댓글 수 서브쿼리 사용.
    - `searchSummariesByKeyword`: 제목/내용/태그 대상 `LIKE` 검색, JPQL Constructor Expression 및 댓글 수 서브쿼리 사용 (성능 경고 주석 포함).

## ✅ 체크리스트

*(PR 제출자가 작성할 부분)*
- [X] 코드 점검 완료
- [ ] 테스트 통과
- [X] 문서/주석 최신화
