### PR TITLE
[feat] ai 매칭 추천 기능 && [fix] 리프레시 토큰 로직 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,8 +48,6 @@ dependencies {
     // build.gradle
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
-// https://mvnrepository.com/artifact/com.github.shin285/KOMORAN
-//    implementation 'com.github.shin285:KOMORAN:3.3.8'
 
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'

--- a/src/main/java/com/team05/linkup/common/application/JwtServiceImpl.java
+++ b/src/main/java/com/team05/linkup/common/application/JwtServiceImpl.java
@@ -5,13 +5,12 @@ import com.team05.linkup.common.exception.TokenException;
 import com.team05.linkup.common.exception.UserNotfoundException;
 import com.team05.linkup.common.oauth.jwtAssistant.OAuth2ProviderStrategy;
 import com.team05.linkup.common.oauth.jwtAssistant.OAuth2ProviderStrategyFactory;
-import com.team05.linkup.domain.user.infrastructure.UserRepository;
 import com.team05.linkup.domain.user.domain.User;
+import com.team05.linkup.domain.user.infrastructure.UserRepository;
 import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -54,6 +53,7 @@ public class JwtServiceImpl implements JwtService {
             return Jwts.builder()
                     .subject(providerId)
                     .claim("authorities",authorities)
+                    .claim("provider", registrationId)
                     .issuedAt(Date.from(now.toInstant()))
                     .expiration(Date.from(expiration.toInstant()))
                     .issuer("cake7-auth-server") // ✅ 발급자 설정
@@ -93,7 +93,8 @@ public class JwtServiceImpl implements JwtService {
             );
 
             // Return authentication with OAuth2User as principal
-            return new UsernamePasswordAuthenticationToken(oAuth2User, null, authorities);
+            return new OAuth2AuthenticationToken
+                    (oAuth2User,  authorities, user.get().getProvider());
 
         } catch (Exception e) {
             logger.error("Error getting authentication: {}", e.getMessage());

--- a/src/main/java/com/team05/linkup/common/application/RefreshTokenService.java
+++ b/src/main/java/com/team05/linkup/common/application/RefreshTokenService.java
@@ -5,5 +5,5 @@ import org.springframework.security.core.Authentication;
 
 public interface RefreshTokenService {
     String createRefreshToken(Authentication authentication) throws Exception;
-    RefreshTokenResponseDTO regenerateAccessAndRefreshToken(String refreshTokenId) throws Exception;
+    RefreshTokenResponseDTO regenerateAccessAndRefreshToken(String provdier, String providerId) throws Exception;
 }

--- a/src/main/java/com/team05/linkup/common/config/SecurityConfig.java
+++ b/src/main/java/com/team05/linkup/common/config/SecurityConfig.java
@@ -54,6 +54,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorizeRequests -> authorizeRequests
                         .requestMatchers("/").permitAll()
                         .requestMatchers("/index.html").permitAll()
+                        .requestMatchers("/v1/auth/refresh").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/oauth2/authorization/google/**").permitAll()
                         .requestMatchers("/oauth2/authorization/kakao/**").permitAll()

--- a/src/main/java/com/team05/linkup/common/util/ApiUtils.java
+++ b/src/main/java/com/team05/linkup/common/util/ApiUtils.java
@@ -1,0 +1,63 @@
+package com.team05.linkup.common.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Optional;
+
+@Component
+public class ApiUtils {
+    private static final Logger logger = LogManager.getLogger(ApiUtils.class);
+
+    private static final HttpClient client = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(5))
+            .build();
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public <T> Optional<T> getApiResponse(String apiUrl, String method, Object requestDto, Class<T> responseType) {
+        try {
+            if (apiUrl == null || method == null) {
+                throw new IllegalArgumentException("API URL 또는 HTTP Method가 null입니다.");
+            }
+
+            String requestBody = requestDto == null ? "" : objectMapper.writeValueAsString(requestDto); // 여기서 DTO를 JSON으로 직렬화
+
+            HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+                    .uri(URI.create(apiUrl))
+                    .timeout(Duration.ofSeconds(5))
+                    .header("Accept", "application/json")
+                    .header("Content-Type", "application/json");
+
+            switch (method.toUpperCase()) {
+                case "POST" -> requestBuilder.POST(HttpRequest.BodyPublishers.ofString(requestBody));
+                case "PUT" -> requestBuilder.PUT(HttpRequest.BodyPublishers.ofString(requestBody));
+                case "DELETE" -> requestBuilder.DELETE();
+                case "GET" -> requestBuilder.GET();
+                default -> throw new UnsupportedOperationException("지원하지 않는 HTTP 메서드입니다: " + method);
+            }
+
+            HttpRequest request = requestBuilder.build();
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() >= 400) {
+                logger.warn("API 호출 실패. 상태 코드: {}, 응답: {}", response.statusCode(), response.body());
+                return Optional.empty();
+            }
+
+            T parsedObject = objectMapper.readValue(response.body(), responseType);
+            return Optional.of(parsedObject);
+        } catch (Exception e) {
+            logger.error("API 호출 중 예외 발생: {}", e.getMessage(), e);
+            return Optional.empty();
+        }
+    }
+
+}

--- a/src/main/java/com/team05/linkup/common/util/JwtUtils.java
+++ b/src/main/java/com/team05/linkup/common/util/JwtUtils.java
@@ -4,6 +4,7 @@ package com.team05.linkup.common.util;
 import com.team05.linkup.common.config.JwtConfig;
 import com.team05.linkup.common.exception.TokenException;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import jakarta.servlet.http.Cookie;
@@ -42,6 +43,22 @@ public class JwtUtils {
         } catch (TokenException e) {
             logger.error("parse token error: {}", e.getMessage());
             throw new JwtException("parse token error");
+        }
+    }
+
+    public Claims parseTokenWithoutExpiredAtValidation(String token) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(jwtConfig.secretKey())
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+        } catch (ExpiredJwtException e) {
+            logger.error("ExpiredJwtException token error: {}", e.getMessage());
+            return e.getClaims();
+        } catch (Exception e) {
+            logger.error("parse token error: {}", e.getMessage());
+            throw new TokenException("parse token error");
         }
     }
 

--- a/src/main/java/com/team05/linkup/domain/enums/ActivityTime.java
+++ b/src/main/java/com/team05/linkup/domain/enums/ActivityTime.java
@@ -11,8 +11,7 @@ public enum ActivityTime {
     WEEKDAY_EVENING("평일저녁"),
     WEEKEND_MORNING("주말오전"),
     WEEKEND_AFTERNOON("주말오후"),
-    WEEKEND_EVENING("주말저녁"),
-    ALL("모두");
+    WEEKEND_EVENING("주말저녁");
 
     private final String displayName;
 

--- a/src/main/java/com/team05/linkup/domain/enums/Role.java
+++ b/src/main/java/com/team05/linkup/domain/enums/Role.java
@@ -10,14 +10,4 @@ public enum Role {
     ROLE_MENTOR,
     ROLE_MENTEE
 
-//    private final String roleName;
-//
-//    public static Role fromRoleName(String name) {
-//        for (Role role : Role.values()) {
-//            if (role.roleName.equals(name)) {
-//                return role;
-//            }
-//        }
-//        throw new IllegalArgumentException("Invalid role: " + name);
-//    }
 }

--- a/src/main/java/com/team05/linkup/domain/mentoring/api/AiMatchingController.java
+++ b/src/main/java/com/team05/linkup/domain/mentoring/api/AiMatchingController.java
@@ -1,7 +1,44 @@
 package com.team05.linkup.domain.mentoring.api;
 
+import com.team05.linkup.common.dto.ApiResponse;
+import com.team05.linkup.common.enums.ResponseCode;
+import com.team05.linkup.common.util.JwtUtils;
+import com.team05.linkup.domain.mentoring.dto.AiMatchingResponseDTO;
+import com.team05.linkup.domain.mentoring.service.AIMatchingServiceImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/v1/matching")
+@RequiredArgsConstructor
+@Tag(name = "ai 매칭 api입니다")
 public class AiMatchingController {
+    private final JwtUtils jwtUtils;
+    private final AIMatchingServiceImpl aiMatchingServiceImpl;
+
+    @GetMapping("/recommendation")
+    @Operation(description = "ai 매칭 멘토 리스트 결과")
+    public ResponseEntity<ApiResponse> getRecommendation(HttpServletRequest request) {
+        try {
+            String token = jwtUtils.extractToken(request);
+            if (token != null && !token.isEmpty()) {
+                boolean isValid = jwtUtils.validateToken(token);
+                if (isValid) {
+                    String providerId = jwtUtils.parseToken(token).getSubject();
+                    AiMatchingResponseDTO responseDTO = aiMatchingServiceImpl.matchMentor(providerId);
+                    return ResponseEntity.ok(ApiResponse.success(responseDTO));
+                }
+            }
+            return ResponseEntity.ok(ApiResponse.error(ResponseCode.UNAUTHORIZED));
+        } catch (Exception e) {
+            return ResponseEntity.ok(ApiResponse.error(ResponseCode.INTERNAL_SERVER_ERROR));
+        }
+
+    }
 }

--- a/src/main/java/com/team05/linkup/domain/mentoring/dto/AiMatchingRequestDTO.java
+++ b/src/main/java/com/team05/linkup/domain/mentoring/dto/AiMatchingRequestDTO.java
@@ -1,0 +1,7 @@
+package com.team05.linkup.domain.mentoring.dto;
+
+import java.util.List;
+
+public record AiMatchingRequestDTO(String profileTag, List<OtherProfile> otherProfiles) {
+    public record OtherProfile(String providerId, String tag) {}
+}

--- a/src/main/java/com/team05/linkup/domain/mentoring/dto/AiMatchingResponseDTO.java
+++ b/src/main/java/com/team05/linkup/domain/mentoring/dto/AiMatchingResponseDTO.java
@@ -1,0 +1,4 @@
+package com.team05.linkup.domain.mentoring.dto;
+
+public record AiMatchingResponseDTO(String profileTag, Object[] results) {
+}

--- a/src/main/java/com/team05/linkup/domain/mentoring/service/AIMatchingServiceImpl.java
+++ b/src/main/java/com/team05/linkup/domain/mentoring/service/AIMatchingServiceImpl.java
@@ -1,0 +1,46 @@
+package com.team05.linkup.domain.mentoring.service;
+
+import com.team05.linkup.common.exception.UserNotfoundException;
+import com.team05.linkup.common.util.ApiUtils;
+import com.team05.linkup.domain.mentoring.dto.AiMatchingRequestDTO;
+import com.team05.linkup.domain.mentoring.dto.AiMatchingResponseDTO;
+import com.team05.linkup.domain.user.infrastructure.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class AIMatchingServiceImpl implements MatchingService {
+    private static final Logger logger = LogManager.getLogger();
+    private final UserRepository userRepository;
+    private final ApiUtils apiUtils;
+
+    @Override
+    public AiMatchingResponseDTO matchMentor(String providerId) {
+        try {
+            String myProfileTag = userRepository.findProfileTagByProviderId(providerId);
+            List<Object[]> resultList = userRepository.findOtherProfileTagsByProviderId(providerId);
+
+            List<AiMatchingRequestDTO.OtherProfile> otherProfiles = resultList.stream().map(obj -> new AiMatchingRequestDTO.OtherProfile(
+                                    (String) obj[0],
+                                    (String) obj[1]
+                            )).toList();
+            AiMatchingRequestDTO requestDTO = new AiMatchingRequestDTO(myProfileTag, otherProfiles);
+            String url = "http://localhost:5000/word-similarity";
+            Optional<AiMatchingResponseDTO> response = apiUtils.getApiResponse(url, "POST", requestDTO, AiMatchingResponseDTO.class);
+            return response.orElseThrow(() -> new UserNotfoundException("mentor is not found"));
+        } catch (UserNotfoundException e) {
+            logger.error("user is not found: {}", e.getMessage());
+            throw new UserNotfoundException("user is not found: " + e.getMessage());
+        } catch (Exception e) {
+            logger.error("Error in matchMentor: {}", e.getMessage());
+            throw new RuntimeException("Error in matchMentor: " + e.getMessage(), e);
+        }
+
+    }
+}

--- a/src/main/java/com/team05/linkup/domain/mentoring/service/MatchingService.java
+++ b/src/main/java/com/team05/linkup/domain/mentoring/service/MatchingService.java
@@ -1,4 +1,7 @@
 package com.team05.linkup.domain.mentoring.service;
 
+import com.team05.linkup.domain.mentoring.dto.AiMatchingResponseDTO;
+
 public interface MatchingService {
+    AiMatchingResponseDTO matchMentor(String providerId);
 }

--- a/src/main/java/com/team05/linkup/domain/mentoring/service/MatchingServiceImpl.java
+++ b/src/main/java/com/team05/linkup/domain/mentoring/service/MatchingServiceImpl.java
@@ -1,4 +1,0 @@
-package com.team05.linkup.domain.mentoring.service;
-
-public class MatchingServiceImpl {
-}

--- a/src/main/java/com/team05/linkup/domain/user/api/ProfileController.java
+++ b/src/main/java/com/team05/linkup/domain/user/api/ProfileController.java
@@ -2,12 +2,11 @@ package com.team05.linkup.domain.user.api;
 
 import com.team05.linkup.common.dto.ApiResponse;
 import com.team05.linkup.common.enums.ResponseCode;
-import com.team05.linkup.domain.mentoring.domain.MentoringSessions;
-import com.team05.linkup.domain.user.domain.User;
 import com.team05.linkup.domain.enums.Role;
-import com.team05.linkup.domain.profile.application.MenteeProfileService;
-import com.team05.linkup.domain.profile.application.MentorProfileService;
-import com.team05.linkup.domain.profile.application.ProfileService;
+import com.team05.linkup.domain.mentoring.domain.MentoringSessions;
+import com.team05.linkup.domain.user.application.MenteeProfileService;
+import com.team05.linkup.domain.user.application.ProfileService;
+import com.team05.linkup.domain.user.domain.User;
 import com.team05.linkup.domain.user.infrastructure.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -29,7 +28,7 @@ public class ProfileController {
 
     private final UserRepository userRepository;
     private final ProfileService profileService;
-    private final MentorProfileService mentorProfileService;
+    private final MenteeProfileService mentorProfileService;
     private final MenteeProfileService menteeProfileService;
 
     @GetMapping("/{nickname}/profile")

--- a/src/main/java/com/team05/linkup/domain/user/application/MenteeProfileService.java
+++ b/src/main/java/com/team05/linkup/domain/user/application/MenteeProfileService.java
@@ -1,4 +1,4 @@
-package com.team05.linkup.domain.profile.application;
+package com.team05.linkup.domain.user.application;
 
 import com.team05.linkup.domain.mentoring.domain.MentoringSessions;
 import com.team05.linkup.domain.mentoring.infrastructure.MentoringRepository;

--- a/src/main/java/com/team05/linkup/domain/user/application/ModifyRoleServiceImpl.java
+++ b/src/main/java/com/team05/linkup/domain/user/application/ModifyRoleServiceImpl.java
@@ -17,10 +17,10 @@ public class ModifyRoleServiceImpl implements ModifyRoleService {
     private final UserRepository userRepository;
 
     @Override
-    public void modifyRole(String userId, Role role) throws Exception {
+    public void modifyRole(String providerId, Role role) throws Exception {
         try {
-            userRepository.updateUserRole(userId, role);
-            logger.debug("Role updated for user: {}", userId);
+            userRepository.updateUserRole(providerId, role);
+            logger.debug("Role updated for user: {}", providerId);
         } catch (UserNotfoundException e) {
             logger.error("User not found: {}", e.getMessage());
             throw new UserNotfoundException("User not found: " + e.getMessage());

--- a/src/main/java/com/team05/linkup/domain/user/application/ProfileService.java
+++ b/src/main/java/com/team05/linkup/domain/user/application/ProfileService.java
@@ -1,4 +1,4 @@
-package com.team05.linkup.domain.profile.application;
+package com.team05.linkup.domain.user.application;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/team05/linkup/domain/user/domain/RefreshToken.java
+++ b/src/main/java/com/team05/linkup/domain/user/domain/RefreshToken.java
@@ -16,6 +16,9 @@ public class RefreshToken {
     @Column(length = 36)
     private String id;
 
+    @Column(length = 36, updatable = false, nullable = false)
+    private String provider;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;

--- a/src/main/java/com/team05/linkup/domain/user/domain/RefreshToken.java
+++ b/src/main/java/com/team05/linkup/domain/user/domain/RefreshToken.java
@@ -21,7 +21,7 @@ public class RefreshToken {
     private User user;
 
     @Column(nullable = false, updatable = false)
-    private ZonedDateTime createdAt = ZonedDateTime.now();
+    private ZonedDateTime createdAt;
 
     @Column(nullable = false)
     private ZonedDateTime expiredAt;

--- a/src/main/java/com/team05/linkup/domain/user/infrastructure/RefreshTokenRepository.java
+++ b/src/main/java/com/team05/linkup/domain/user/infrastructure/RefreshTokenRepository.java
@@ -14,8 +14,8 @@ import java.util.Optional;
 @Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, String> {
 
-    @Query("SELECT r FROM RefreshToken r JOIN FETCH r.user u WHERE u.providerId = :providerId AND r.used = false")
-    Optional<RefreshToken> findByProviderId(@Param("providerId") String providerId);
+    @Query("SELECT r FROM RefreshToken r JOIN FETCH r.user u WHERE u.provider = :provider AND u.providerId = :providerId AND r.used = false")
+    Optional<RefreshToken> findByProviderAndProviderId(@Param("provider") String provider, @Param("providerId") String providerId);
 
     @Modifying
     @Query("UPDATE RefreshToken r SET r.used = true WHERE r.user = :userId AND r.used = false")

--- a/src/main/java/com/team05/linkup/domain/user/infrastructure/UserRepository.java
+++ b/src/main/java/com/team05/linkup/domain/user/infrastructure/UserRepository.java
@@ -39,7 +39,7 @@ public interface UserRepository extends JpaRepository<User, String> {
     String findProfileTagByProviderId(@Param("providerId") String providerId);
 
     @Query("""
-        SELECT u.providerId, u.profileImageUrl
+        SELECT u.providerId, u.profileTag
         FROM User u
         WHERE u.providerId <> :providerId
     """)

--- a/src/main/java/com/team05/linkup/domain/user/infrastructure/UserRepository.java
+++ b/src/main/java/com/team05/linkup/domain/user/infrastructure/UserRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -29,4 +30,19 @@ public interface UserRepository extends JpaRepository<User, String> {
                 WHERE u.providerId = :providerId AND u.role = 'ROLE_TEMP'
           """)
     void updateUserRole(@Param("providerId") String id, @Param("role") Role role);
+
+    @Query("""
+        SELECT u.profileTag
+        FROM User u
+        WHERE u.providerId = :providerId
+    """)
+    String findProfileTagByProviderId(@Param("providerId") String providerId);
+
+    @Query("""
+        SELECT u.providerId, u.profileImageUrl
+        FROM User u
+        WHERE u.providerId <> :providerId
+    """)
+    List<Object[]> findOtherProfileTagsByProviderId(@Param("providerId") String providerId);
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
     show-sql: true # SQL 로그 출력
     properties:
       hibernate:


### PR DESCRIPTION
## ✨ PR 종류

- [x] 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 🛠️ 작업 요약

- 리프레시 토큰 로직 수정, ai 매칭 기능 추가

## 📝 작업 상세

- 작업 1: ai 매칭 추천 로직을 구현했습니다
- 작업 2: 리프레시 토큰 발급 로직을 수정했습니다. 기존 로직은 엑세스 토큰이 만료되면 발급받을 수 없었지만, 현재 로직은 리프레시 토큰이 만료가 됐고, sign이 valid하다면 발급받도록 수정했습니다
- 작업 3: 토큰 claim에 provider을 담아 providerAndproviderId 로 쿼리를 날려 구글과 카카오가 providerId가 겹치는 경우를 고려하여 기능을 개선햇습니다.

## ✅ 체크리스트

- [x] 코드 점검 완료
- [x] 테스트 통과
- [ ] 문서/주석 최신화

## 📚 기타

- (선택사항)