### PR TITLE
[refactor] '좋아요' 기능 API 방식 리팩토링

### DIFF
--- a/src/main/java/com/team05/linkup/domain/community/api/LikeController.java
+++ b/src/main/java/com/team05/linkup/domain/community/api/LikeController.java
@@ -1,9 +1,9 @@
 package com.team05.linkup.domain.community.api;
 
-
 import com.team05.linkup.common.dto.ApiResponse;
 import com.team05.linkup.common.enums.ResponseCode;
 import com.team05.linkup.domain.community.application.LikeService;
+import com.team05.linkup.domain.community.dto.LikeStatusResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -23,48 +23,24 @@ public class LikeController {
     private final LikeService likeService;
 
     /**
-     * 현재 인증된 사용자가 특정 커뮤니티 게시글에 '좋아요'를 추가.
+     * 현재 인증된 사용자가 특정 커뮤니티 게시글의 '좋아요' 상태를 토글합니다.
+     * (좋아요 상태 -> 좋아요 취소 / 좋아요 아닌 상태 -> 좋아요 추가)
      *
-     * @param communityId 좋아요를 추가할 게시글의 ID (경로 변수).
-     * @param providerId 현재 인증된 사용자 정보 (Spring Security가 주입).
-     * @return 성공 시 200 OK 응답. 사용자가 없으면 401 Unauthorized.
-     */
-    @Operation(summary = "게시글 좋아요 추가", description = "특정 커뮤니티 게시글에 좋아요를 추가합니다.")
-    @PostMapping
-    public ResponseEntity<ApiResponse<Void>> addLike(
-            @PathVariable String communityId,
-            @AuthenticationPrincipal String providerId
-    ) {
-        // 1. 사용자 정보 확인 (providerId가 null이면 인증되지 않은 사용자)
-        if (providerId == null) {
-            return ResponseEntity.status(401).body(ApiResponse.error(ResponseCode.UNAUTHORIZED));
-        }
-        // 2. 서비스 호출하여 좋아요 추가 로직 수행
-        likeService.addLike(providerId, communityId); // String 타입 ID 전달
-        // 3. 성공 응답 반환
-        return ResponseEntity.ok(ApiResponse.success());
-    }
-
-    /**
-     * 현재 인증된 사용자가 특정 커뮤니티 게시글에 누른 '좋아요'를 취소.
-     *
-     * @param communityId 좋아요를 취소할 게시글의 ID (경로 변수).
+     * @param communityId 토글할 게시글의 ID (경로 변수).
      * @param providerId  현재 인증된 사용자 정보 (Spring Security가 주입).
-     * @return 성공 시 200 OK 응답. 사용자가 없으면 401 Unauthorized.
+     * @return 토글 후의 최종 '좋아요' 상태를 담은 응답 (liked: true/false).
      */
-    @Operation(summary = "게시글 좋아요 취소", description = "특정 커뮤니티 게시글의 좋아요를 취소합니다.")
-    @DeleteMapping
-    public ResponseEntity<ApiResponse<Void>> removeLike(
+    @Operation(summary = "게시글 좋아요 토글", description = "특정 커뮤니티 게시글의 좋아요 상태를 변경(토글)합니다.")
+    @PostMapping
+    public ResponseEntity<ApiResponse<LikeStatusResponse>> toggleLike(
             @PathVariable String communityId,
             @AuthenticationPrincipal String providerId
     ) {
-        // 1. 사용자 정보 확인
         if (providerId == null) {
             return ResponseEntity.status(401).body(ApiResponse.error(ResponseCode.UNAUTHORIZED));
         }
-        // 2. 서비스 호출하여 좋아요 취소 로직 수행
-        likeService.removeLike(providerId, communityId);
-        // 3. 성공 응답 반환
-        return ResponseEntity.ok(ApiResponse.success());
+
+        boolean liked = likeService.toggleLike(providerId, communityId);
+        return ResponseEntity.ok(ApiResponse.success(new LikeStatusResponse(liked)));
     }
 }

--- a/src/main/java/com/team05/linkup/domain/community/application/LikeService.java
+++ b/src/main/java/com/team05/linkup/domain/community/application/LikeService.java
@@ -22,92 +22,45 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class LikeService {
 
-    private final LikeRepository communityLikeRepository;
+    private final LikeRepository likeRepository;
     private final CommunityRepository communityRepository;
-    private final UserRepository userRepository; // Inject UserRepository
+    private final UserRepository userRepository;
 
     /**
-     * 사용자가 특정 커뮤니티 게시글에 '좋아요'를 추가.
-     * 트랜잭션 내에서 실행되며, 다음 작업들을 포함.
-     * 성공 시 Community의 likeCount를 1 증가시킵니다.
-     * 1. 사용자(User)와 커뮤니티 게시글(Community) 엔티티를 조회. (없으면 EntityNotFoundException 발생)
-     * 2. 이미 해당 사용자가 해당 게시글에 '좋아요'를 눌렀는지 확인.
-     * 3. 좋아요를 누르지 않았다면, 새로운 'Like' 엔티티를 생성하고 저장.
-     * 4. 해당 커뮤니티 게시글의 'likeCount'를 1 증가.
+     * 사용자가 특정 커뮤니티 게시글에 대한 '좋아요' 상태를 토글합니다.
+     * 이미 '좋아요' 상태이면 취소하고, 아니면 '좋아요'를 추가합니다.
      *
-     * @param providerId                좋아요를 누르는 사용자의 Provider ID.
-     * @param communityId               좋아요 대상 게시글의 ID.
-     * @throws EntityNotFoundException  사용자 또는 게시글을 찾을 수 없는 경우 발생.
+     * @param providerId  토글 요청 사용자 Provider ID.
+     * @param communityId 대상 게시글 ID.
+     * @return 토글 후의 최종 '좋아요' 상태 (true: 좋아요, false: 좋아요 아님).
+     * @throws EntityNotFoundException 사용자 또는 게시글을 찾을 수 없는 경우.
      */
     @Transactional //
-    public void addLike(String providerId, String communityId) {
+    public boolean toggleLike(String providerId, String communityId) {
         // 1. 사용자 및 커뮤니티 엔티티 조회
         User user = userRepository.findByProviderId(providerId)
                 .orElseThrow(() -> new EntityNotFoundException("User not found with PID: " + providerId));
         Community community = communityRepository.findById(communityId)
                 .orElseThrow(() -> new EntityNotFoundException("Community not found with CID: " + communityId));
 
-        // 2. 이미 좋아요를 눌렀는지 확인
-        if (communityLikeRepository.findByUserAndCommunity(user, community).isEmpty()) {
-            // 3. 좋아요 정보 생성 및 저장
+        Optional<Like> existingLike = likeRepository.findByUserAndCommunity(user, community);
+
+        if (existingLike.isPresent()) {
+            // 좋아요가 있으면 -> 취소
+            likeRepository.delete(existingLike.get());
+            communityRepository.decrementLikeCount(communityId);
+            log.debug("UserPID {} unliked community {}", providerId, communityId);
+            return false; // 최종 상태: 좋아요 아님
+        } else {
+            // 좋아요가 없으면 -> 추가
             Like like = Like.builder()
                     .user(user)
                     .community(community)
                     .build();
-            communityLikeRepository.save(like);
-
-            // 4. Community 게시글의 좋아요 카운트 증가
-            int updatedRows = communityRepository.incrementLikeCount(communityId);
-            if (updatedRows == 0) {
-                // 일반적으로 발생하지 않지만, 동시성 문제 등으로 업데이트가 실패할 경우 로깅
-                log.warn("Failed to increment like count for community {} (maybe deleted concurrently?)", communityId);
-                // 필요 시, 비즈니스 로직에 따라 예외 발생 또는 보상 트랜잭션 고려
-            }
-            log.info("UserPID {} liked community {}", providerId, communityId);
-        } else {
-            // 이미 좋아요를 누른 경우, 추가 작업 없이 로깅만 수행
-            log.info("UserPID {} already liked community {}", providerId, communityId);
-            // 필요 시, 클라이언트에게 이미 처리되었음을 알리는 응답 또는 예외 반환 고려
-        }
-    }
-
-    /**
-     * 사용자가 특정 커뮤니티 게시글에 누른 '좋아요'를 취소.
-     * 트랜잭션 내에서 실행되며, 다음 작업들을 포함:
-     * 1. 사용자(User)와 커뮤니티 게시글(Community) 엔티티를 조회. (없으면 EntityNotFoundException 발생)
-     * 2. 취소할 '좋아요' 레코드를 조회.
-     * 3. '좋아요' 레코드가 존재하면 삭제.
-     * 4. 해당 커뮤니티 게시글의 'likeCount'를 1 감소.
-     *
-     * @param providerId      좋아요를 취소하는 사용자의 Provider ID.
-     * @param communityId 좋아요를 취소할 대상 게시글의 ID.
-     * @throws EntityNotFoundException 사용자 또는 게시글을 찾을 수 없는 경우.
-     */
-    @Transactional
-    public void removeLike(String providerId, String communityId) {
-        // 1. 사용자 및 커뮤니티 엔티티 조회
-        User user = userRepository.findByProviderId(providerId)
-                .orElseThrow(() -> new EntityNotFoundException("User not found with PID: " + providerId));
-        Community community = communityRepository.findById(communityId)
-                .orElseThrow(() -> new EntityNotFoundException("Community not found with CID: " + communityId));
-
-        // 2. 취소할 좋아요 정보 조회
-        Optional<Like> existingLike = communityLikeRepository.findByUserAndCommunity(user, community);
-
-        if (existingLike.isPresent()) {
-            // 3. 좋아요 정보 삭제
-            communityLikeRepository.delete(existingLike.get());
-
-            // 4. Community 게시글의 좋아요 카운트 감소
-            int updatedRows = communityRepository.decrementLikeCount(communityId);
-            if (updatedRows == 0) {
-                // 카운트가 이미 0이었거나, 동시성 문제 등으로 업데이트가 실패할 경우 로깅
-                log.warn("Failed to decrement like count for community {} (maybe deleted concurrently or count was 0?)", communityId);
-            }
-            log.info("UserPID {} unliked community {}", providerId, communityId);
-        } else {
-            // 좋아요를 누르지 않았거나 이미 취소된 경우, 추가 작업 없이 로깅만 수행
-            log.info("UserPID {} had not liked community {} or like already removed", providerId, communityId);
+            likeRepository.save(like);
+            communityRepository.incrementLikeCount(communityId);
+            log.debug("UserPID {} liked community {}", providerId, communityId);
+            return true; // 최종 상태: 좋아요
         }
     }
 }

--- a/src/main/java/com/team05/linkup/domain/community/dto/LikeStatusResponse.java
+++ b/src/main/java/com/team05/linkup/domain/community/dto/LikeStatusResponse.java
@@ -1,0 +1,4 @@
+package com.team05.linkup.domain.community.dto;
+
+public record LikeStatusResponse(boolean liked) {
+}


### PR DESCRIPTION
## ✨ PR 종류

- [X] 기능 추가
- [X] 리팩토링  *(Like API 리팩토링 포함)*
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 기타 *(스키마 변경 포함)*

## 🛠️ 작업 요약

- 커뮤니티 게시글 '좋아요' 기능을 단일 토글(Toggle) API 방식으로 리팩토링했습니다. (기존 추가/삭제 API 통합)
- 사용자는 `POST /like` 엔드포인트 하나로 '좋아요' 상태를 변경하고, 변경된 최종 상태를 응답받습니다.
- 게시글의 `likeCount`는 실시간으로 업데이트됩니다.

## 📝 작업 상세

**1. 좋아요 기능 리팩토링:**

- **`LikeStatusResponse.java` (DTO 추가):**
    - '좋아요' 토글 API의 응답 형식을 위한 `LikeStatusResponse` record DTO 추가 (`boolean liked` 필드 포함).
    
- **`LikeService.java` (Service 리팩토링):**
    - 기존 `addLike`, `removeLike` 메소드 제거.
    - `toggleLike` 메소드 구현:
        - `User`, `Community` 엔티티 조회.
        - `LikeRepository.findByUserAndCommunity`로 기존 '좋아요' 상태 확인.
        - 상태에 따라 `Like` 레코드 생성 또는 삭제 수행.
        - `CommunityRepository`의 `incrementLikeCount`/`decrementLikeCount` 호출하여 카운트 업데이트.
        - 최종 '좋아요' 상태 (`boolean`)를 반환.
        - `@Transactional` 적용.
        
- **`LikeController.java` (Controller 리팩토링):**
    - 기존 `POST /like`, `DELETE /like` 엔드포인트 로직 통합 및 수정.
    - 단일 `POST /v1/community/{communityId}/like` 엔드포인트 유지:
        - `likeService.toggleLike` 호출.
        - `LikeStatusResponse` DTO를 사용하여 토글 후의 최종 '좋아요' 상태를 응답.

- **`Like.java` (Entity):** *(변경 없음)*
    - `User`와 `Community` 간의 '좋아요' 관계 엔티티 정의 유지.
    
- **`LikeRepository.java` (Repository):** *(변경 없음)*
    - `Like` 엔티티 JpaRepository 및 `findByUserAndCommunity` 메소드 유지.
    
- **`CommunityRepository.java` (Repository):** *(변경 없음)*
    - `incrementLikeCount`, `decrementLikeCount` 메소드 유지 (토글 로직에서 사용).

## ✅ 체크리스트

- [X] 코드 점검 완료
- [X] 테스트 통과
- [X] 문서/주석 최신화

---