### PR TITLE
 [refactor] '좋아요' 기능 리팩토링

### DIFF
--- a/src/main/java/com/team05/linkup/domain/community/api/LikeController.java
+++ b/src/main/java/com/team05/linkup/domain/community/api/LikeController.java
@@ -14,9 +14,9 @@ import org.springframework.web.bind.annotation.*;
 /**
  * 커뮤니티 게시글의 '좋아요' 관련 HTTP 요청을 처리하는 컨트롤러.
  */
-@Tag(name = "Like API", description = "커뮤니티 게시글 좋아요 관련 API")
+@Tag(name = "커뮤니티 API", description = "커뮤니티 게시글 좋아요 관련 API")
 @RestController
-@RequestMapping("/v1/community/{communityId}/like")
+@RequestMapping("/v1/community/details/{communityId}/like")
 @RequiredArgsConstructor
 public class LikeController {
 

--- a/src/main/java/com/team05/linkup/domain/community/domain/Like.java
+++ b/src/main/java/com/team05/linkup/domain/community/domain/Like.java
@@ -4,7 +4,6 @@ import com.team05.linkup.domain.baseEntity.BaseEntity; // BaseEntity 사용 시
 import com.team05.linkup.domain.user.domain.User;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.UuidGenerator; // UUID 사용 시
 
 /**
  * 사용자가 커뮤니티 게시글에 대해 '좋아요'를 표시하는 관계를 나타내는 엔티티.
@@ -16,14 +15,13 @@ import org.hibernate.annotations.UuidGenerator; // UUID 사용 시
 @Entity
 @Table(name = "likes", uniqueConstraints = {
                 @UniqueConstraint(columnNames = {"user_id", "community_id"})})
-public class Like  extends BaseEntity {
+public class Like extends BaseEntity {
 
     /**
      * '좋아요' 레코드의 고유 식별자 (UUID, 시간 기반 생성).
      */
     @Id
-    @GeneratedValue(generator = "uuid2") // UUID 자동 생성 전략
-    @UuidGenerator(style = UuidGenerator.Style.TIME)
+    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(length = 36)
     private String id;
 

--- a/src/main/java/com/team05/linkup/domain/community/infra/LikeRepository.java
+++ b/src/main/java/com/team05/linkup/domain/community/infra/LikeRepository.java
@@ -16,6 +16,15 @@ import java.util.Optional;
 public interface LikeRepository extends JpaRepository<Like, String> {
 
     /**
+     * 특정 사용자와 커뮤니티 게시글에 대한 '좋아요' 존재 여부를 확인합니다.
+     *
+     * @param user        확인할 사용자 엔티티
+     * @param communityId 확인할 커뮤니티 게시글 ID
+     * @return '좋아요'가 존재하면 true, 그렇지 않으면 false
+     */
+    boolean existsByUserAndCommunityId(User user, String communityId); // 사용자 객체 기반 확인
+
+    /**
      * 특정 사용자와 특정 커뮤니티 게시글에 대한 '좋아요' 정보를 조회.
      * 사용자가 해당 게시글에 좋아요를 눌렀는지 확인하는 데 사용.
      *


### PR DESCRIPTION
## ✨ PR 종류

- [X] 기능 추가
- [X] 리팩토링
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 기타

## 🛠️ 작업 요약

- `LikeRepository`에 사용자 및 커뮤니티 ID 기반 '좋아요' 존재 확인 메소드를 추가했습니다.
- `LikeController`의 API 경로 및 Swagger 태그를 수정했습니다.
- `Like` 엔티티의 ID 생성 전략을 표준 JPA 방식으로 리팩토링했습니다.

## 📝 작업 상세

- **`LikeRepository.java`:**
    - `boolean existsByUserAndCommunityId(User user, String communityId)` 메소드를 추가하여, 특정 사용자와 게시글 ID에 대한 '좋아요' 존재 여부를 효율적으로 확인할 수 있는 기능을 추가했습니다.

- **`LikeController.java`:**
    - API 기본 경로를 `/v1/community/{communityId}/like` 에서 `/v1/community/details/{communityId}/like` 로 변경하여 경로 구조를 수정했습니다.
    - Swagger 문서 태그(`@Tag`)의 이름을 "Like API"에서 "커뮤니티 API"로 변경했습니다.

- **`Like.java` (Entity):**
    - ID 필드(`id`)의 UUID 생성 전략을 Hibernate 특정 방식(`@UuidGenerator`)에서 표준 JPA 방식(`@GeneratedValue(strategy = GenerationType.UUID)`)으로 변경하여 코드를 표준화하고 단순화했습니다.

## ✅ 체크리스트

- [X] 코드 점검 완료
- [X] 테스트 통과
- [X] 문서/주석 최신화