### PR TITLE
[feat] 북마크 토글 기능 구현

### DIFF
--- a/src/main/java/com/team05/linkup/domain/community/api/BookmarkController.java
+++ b/src/main/java/com/team05/linkup/domain/community/api/BookmarkController.java
@@ -1,0 +1,52 @@
+package com.team05.linkup.domain.community.api;
+
+import com.team05.linkup.common.dto.ApiResponse;
+import com.team05.linkup.common.enums.ResponseCode;
+import com.team05.linkup.domain.community.application.BookmarkService;
+import com.team05.linkup.domain.community.dto.BookmarkStatusResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 커뮤니티 게시글의 '북마크' 관련 HTTP 요청을 처리하는 컨트롤러.
+ */
+@Tag(name = "커뮤니티 API", description = "커뮤니티 게시글 북마크 관련 API")
+@RestController
+@RequestMapping("/v1/community/details/")
+@RequiredArgsConstructor
+public class BookmarkController {
+
+    private final BookmarkService bookmarkService;
+
+    /**
+     * 현재 인증된 사용자가 특정 커뮤니티 게시글의 '북마크' 상태를 토글.
+     * (북마크 상태 -> 북마크 취소 / 북마크 아닌 상태 -> 북마크 추가)
+     *
+     * @param communityId 토글할 게시글의 ID (경로 변수).
+     * @param providerId  현재 인증된 사용자 정보 (Spring Security가 주입).
+     * @return 토글 후의 최종 북마크 상태(bookmarked: true/false)를 담은 응답.
+     */
+    @Operation(summary = "게시글 북마크 토글", description = "특정 커뮤니티 게시글의 북마크 상태를 변경(토글).")
+    @PostMapping("{communityId}/bookmark")
+    public ResponseEntity<ApiResponse<BookmarkStatusResponse>> toggleBookmark(
+            @PathVariable String communityId,
+            @AuthenticationPrincipal String providerId
+    ) {
+        if (providerId == null) {
+            return ResponseEntity
+                    .status(ResponseCode.UNAUTHORIZED.getStatus())
+                    .body(ApiResponse.error(ResponseCode.UNAUTHORIZED));
+        }
+
+        // 서비스 호출하여 토글 실행 및 최종 상태 받기
+        boolean isBookmarked = bookmarkService.toggleBookmark(providerId, communityId);
+
+        // 성공 응답 반환 (최종 상태 포함)
+        return ResponseEntity.ok(ApiResponse.success(new BookmarkStatusResponse(isBookmarked)));
+    }
+
+}

--- a/src/main/java/com/team05/linkup/domain/community/application/BookmarkService.java
+++ b/src/main/java/com/team05/linkup/domain/community/application/BookmarkService.java
@@ -1,0 +1,67 @@
+package com.team05.linkup.domain.community.application;
+
+import com.team05.linkup.domain.community.domain.Bookmark;
+import com.team05.linkup.domain.community.domain.Community;
+import com.team05.linkup.domain.community.infra.BookmarkRepository;
+import com.team05.linkup.domain.community.infra.CommunityRepository;
+import com.team05.linkup.domain.user.domain.User;
+import com.team05.linkup.domain.user.infrastructure.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+/**
+ * 커뮤니티 게시글의 '북마크' 기능과 관련된 비즈니스 로직을 처리하는 서비스 클래스.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BookmarkService {
+
+    private final BookmarkRepository bookmarkRepository;
+    private final UserRepository userRepository;
+    private final CommunityRepository communityRepository;
+
+    /**
+     * 사용자가 특정 커뮤니티 게시글에 대한 '북마크' 상태를 토글.
+     * 이미 북마크 상태이면 취소하고, 아니면 북마크를 추가.
+     *
+     * @param providerId  토글 요청 사용자 Provider ID.
+     * @param communityId 대상 게시글 ID.
+     * @return 토글 후의 최종 북마크 상태 (true: 북마크됨, false: 북마크 안됨).
+     * @throws EntityNotFoundException 사용자 또는 게시글을 찾을 수 없는 경우.
+     */
+    @Transactional
+    public boolean toggleBookmark(String providerId, String communityId) {
+        // 1. 사용자 및 커뮤니티 엔티티 조회
+        User user = userRepository.findByProviderId(providerId)
+                .orElseThrow(() -> new EntityNotFoundException("User not found with PID: " + providerId));
+        Community community = communityRepository.findById(communityId)
+                .orElseThrow(() -> new EntityNotFoundException("Community not found with CID: " + communityId));
+
+        // 2. 기존 북마크 조회
+        Optional<Bookmark> existingBookmark = bookmarkRepository.findByUserAndCommunityId(user, communityId);
+
+
+        if (existingBookmark.isPresent()) {
+            // 북마크가 있으면 -> 삭제
+            bookmarkRepository.delete(existingBookmark.get());
+            log.debug("UserPID {} removed bookmark for community {}", providerId, communityId);
+            return false; // 최종 상태: 북마크 안됨
+        } else {
+            // 북마크가 없으면 -> 추가
+            Bookmark bookmark = Bookmark.builder()
+                    .user(user)
+                    .community(community)
+                    .build();
+            bookmarkRepository.save(bookmark);
+            log.debug("UserPID {} added bookmark for community {}", providerId, communityId);
+            return true; // 최종 상태: 북마크됨
+        }
+    }
+
+}

--- a/src/main/java/com/team05/linkup/domain/community/domain/Bookmark.java
+++ b/src/main/java/com/team05/linkup/domain/community/domain/Bookmark.java
@@ -1,0 +1,60 @@
+package com.team05.linkup.domain.community.domain;
+
+import com.team05.linkup.domain.baseEntity.BaseEntity;
+import com.team05.linkup.domain.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 사용자가 커뮤니티 게시글을 북마크하는 관계를 나타내는 엔티티 클래스.
+ * {@link User}와 {@link Community} 간의 다대다 관계를 매핑. (실제로는 일대다 매핑 테이블)
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "bookmark",
+        uniqueConstraints = {@UniqueConstraint(name = "uk_user_community", columnNames = {"user_id", "community_id"})}
+)
+public class Bookmark extends BaseEntity { // BaseEntity 상속 (createdAt, updatedAt 자동 관리 가정)
+
+    /**
+     * 북마크의 고유 식별자 (UUID).
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(length = 36)
+    private String id;
+
+    /**
+     * 북마크를 한 사용자 엔티티.
+     * 지연 로딩(LAZY)을 사용하여 성능 최적화.
+     * 사용자가 삭제되면 관련 북마크도 함께 삭제됩니다(ON DELETE CASCADE DB 제약조건 필요).
+     */
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    /**
+     * 북마크된 커뮤니티 게시글 엔티티.
+     * 지연 로딩(LAZY)을 사용하여 성능 최적화.
+     * 게시글이 삭제되면 관련 북마크도 함께 삭제됩니다(ON DELETE CASCADE DB 제약조건 필요).
+     */
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "community_id", nullable = false)
+    private Community community;
+
+    /**
+     * 북마크 생성을 위한 빌더 패턴 생성자.
+     *
+     * @param user      북마크를 하는 사용자
+     * @param community 북마크 대상 게시글
+     */
+    @Builder
+    public Bookmark(User user, Community community) {
+        this.user = user;
+        this.community = community;
+    }
+}

--- a/src/main/java/com/team05/linkup/domain/community/dto/BookmarkStatusResponse.java
+++ b/src/main/java/com/team05/linkup/domain/community/dto/BookmarkStatusResponse.java
@@ -1,0 +1,9 @@
+package com.team05.linkup.domain.community.dto;
+
+/**
+ * 북마크 토글 작업 후의 최종 상태를 나타내는 DTO.
+ *
+ * @param bookmarked 북마크 상태 (true: 북마크됨, false: 북마크 안됨)
+ */
+public record BookmarkStatusResponse(boolean bookmarked) {
+}

--- a/src/main/java/com/team05/linkup/domain/community/infra/BookmarkRepository.java
+++ b/src/main/java/com/team05/linkup/domain/community/infra/BookmarkRepository.java
@@ -1,0 +1,33 @@
+package com.team05.linkup.domain.community.infra;
+
+import com.team05.linkup.domain.community.domain.Bookmark;
+import com.team05.linkup.domain.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ * {@link Bookmark} 엔티티에 대한 데이터 접근 작업을 처리하는 Spring Data JPA 리포지토리 인터페이스.
+ */
+public interface BookmarkRepository extends JpaRepository<Bookmark, String> {
+
+    /**
+     * 특정 사용자와 커뮤니티 게시글에 대한 북마크 존재 여부를 확인합니다.
+     *
+     * @param user        확인할 사용자 엔티티
+     * @param communityId 확인할 커뮤니티 게시글 ID
+     * @return 북마크가 존재하면 true, 그렇지 않으면 false
+     */
+    boolean existsByUserAndCommunityId(User user, String communityId); // 사용자 객체 기반 확인
+
+    /**
+     * 특정 사용자와 커뮤니티 게시글에 해당하는 북마크 정보를 조회합니다.
+     * 토글 로직에서 기존 북마크를 삭제하기 위해 사용됩니다.
+     *
+     * @param user        조회할 사용자 엔티티
+     * @param communityId 조회할 커뮤니티 게시글 ID
+     * @return Optional<Bookmark> 객체. 북마크가 존재하면 해당 엔티티를, 없으면 비어있는 Optional을 반환합니다.
+     */
+    Optional<Bookmark> findByUserAndCommunityId(User user, String communityId); // 사용자 객체 기반 조회
+
+}


### PR DESCRIPTION
## ✨ PR 종류

- [X] 기능 추가
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 기타

## 🛠️ 작업 요약

- 커뮤니티 게시글에 대한 **북마크(Bookmark) 토글 기능**을 신규 구현했습니다. (API, Service, Repository, Entity, DTO 포함)

## 📝 작업 상세

**1. 북마크(Bookmark) 기능 신규 구현:**

- **`Bookmark.java` (Entity):**
    - 사용자와 커뮤니티 게시글 간의 북마크 관계를 정의하는 엔티티 추가 (`User`, `Community`와 ManyToOne, UUID PK).
    
- **`BookmarkRepository.java` (Repository):**
    - `JpaRepository`를 상속받는 북마크 리포지토리 추가.
    - `existsByUserAndCommunityId`, `findByUserAndCommunityId` 쿼리 메소드 포함.
    
- **`BookmarkService.java` (Service):**
    - `@Transactional` 기반의 북마크 토글 로직 구현 (기존 북마크 확인 후 생성 또는 삭제).
    
- **`BookmarkController.java` (Controller):**
    - `POST /v1/community/details/{communityId}/bookmark` 엔드포인트 추가.
    - `BookmarkService`를 호출하여 토글 로직 실행 및 최종 상태(`BookmarkStatusResponse`) 응답.
    
- **`BookmarkStatusResponse.java` (DTO):**
    - 북마크 토글 후 최종 상태(`boolean bookmarked`)를 담는 응답 DTO 추가.

## ✅ 체크리스트

- [X] 코드 점검 완료
- [X] 테스트 통과
- [X] 문서/주석 최신화

---