### PR TITLE
[refactor] ProfileController 역할 분기 외 로직 제거 및 응답 구조 Map → DTO 리팩토링

### DIFF
--- a/src/main/java/com/team05/linkup/domain/user/api/ProfileController.java
+++ b/src/main/java/com/team05/linkup/domain/user/api/ProfileController.java
@@ -2,29 +2,28 @@ package com.team05.linkup.domain.user.api;
 
 import com.team05.linkup.common.dto.ApiResponse;
 import com.team05.linkup.common.enums.ResponseCode;
-import com.team05.linkup.domain.mentoring.dto.MatchedMentorProfileDto;
-import com.team05.linkup.domain.user.domain.User;
 import com.team05.linkup.domain.community.dto.CommunityTalentSummaryDTO;
 import com.team05.linkup.domain.enums.Role;
+import com.team05.linkup.domain.mentoring.dto.MatchedMentorProfileDto;
 import com.team05.linkup.domain.user.application.MenteeProfileService;
 import com.team05.linkup.domain.user.application.MentorProfileService;
 import com.team05.linkup.domain.user.application.ProfileService;
+import com.team05.linkup.domain.user.domain.User;
+import com.team05.linkup.domain.user.dto.ActivityResponseDTO;
 import com.team05.linkup.domain.user.dto.ProfilePageDTO;
 import com.team05.linkup.domain.user.infrastructure.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 @Slf4j
@@ -62,40 +61,28 @@ public class ProfileController {
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
                     .body(ApiResponse.error(ResponseCode.ENTITY_NOT_FOUND, "프로필을 찾을 수 없습니다."));
 
-//        Map<String, Object> data = new HashMap<>();
-
         User profile = userOpt.get();
-//        log.info("✅ 현재 사용자 닉네임 = {}", nickname);
-//        log.info("✅ 역할 = {}", user.getRole());
         logger.debug(profile.getRole());
-        Map<String, Object> data = getCommonActivity(nickname); // 공통 조회 항목들 불러오기
+
+        // 공통 조회 항목 - Controller에서는 입출력과 역할 분기만 담당 (리팩토링)
+//        Map<String, Object> data = profileService.getCommonActivity(nickname);
+        ActivityResponseDTO.ActivityResponseDTOBuilder builder =
+                profileService.getCommonActivityDTO(nickname).toBuilder();
 
 
         if (profile.getRole().equals(Role.ROLE_MENTOR)) {
             // 멘토의 경우, 커뮤니티 재능나눔 게시글 작성 내역 조회하여 반환
-//            log.info("✅ 멘토 맞음, 재능 데이터 조회 시작!");
             List<CommunityTalentSummaryDTO> talents = mentorProfileService.getCommunityTalents(nickname, 2);
-//            log.info("✅ 재능 개수: {}", talents.size());
-            data.put("talents", talents);
+            builder.talents(talents);
 
         } else if (profile.getRole().equals(Role.ROLE_MENTEE)) {
             // 멘티의 경우, 내가 신청한 매칭의 멘토 정보를 조회하여 반환
             List<MatchedMentorProfileDto> matches = menteeProfileService.getMyMentoringSessions(profile.getId(), 2);
-            data.put("matches", matches);
+            builder.matches(matches);
             logger.debug("멘티의 매칭 내역 조회 성공");
         }
 
-        return ResponseEntity.ok(ApiResponse.success(data));
+        return ResponseEntity.ok(ApiResponse.success(builder.build()));
     }
-    /**
-     *  활동 내역 중 공통 항목을 한 번에 불러오는 private 메서드
-     */
-    private Map<String, Object> getCommonActivity (String nickname){
-        Map<String, Object> data = new HashMap<>();
-        data.put("posts", profileService.getMyPosts(nickname, 2));
-        data.put("comments", profileService.getMyComments(nickname, 2));
-        data.put("bookmarks", profileService.getMyBookmarks(nickname, 1));
-        data.put("likes", profileService.getMyLikePosts(nickname, 1));
-        return data;
-    }
+
 }

--- a/src/main/java/com/team05/linkup/domain/user/application/ProfileService.java
+++ b/src/main/java/com/team05/linkup/domain/user/application/ProfileService.java
@@ -111,4 +111,17 @@ public class ProfileService {
                 .collect(Collectors.toList());
     }
 
+    /**
+     *  활동 내역 중 공통 항목
+     *  (서비스 단으로 리팩터링
+     *      && Map<String, Object> -> DTO 형태로 변경)
+     */
+    public ActivityResponseDTO getCommonActivityDTO(String nickname) {
+        return ActivityResponseDTO.builder()
+                .posts(getMyPosts(nickname, 2))
+                .comments(getMyComments(nickname, 2))
+                .bookmarks(getMyBookmarks(nickname, 1))
+                .likes(getMyLikePosts(nickname, 1))
+                .build();
+    }
 }

--- a/src/main/java/com/team05/linkup/domain/user/dto/ActivityResponseDTO.java
+++ b/src/main/java/com/team05/linkup/domain/user/dto/ActivityResponseDTO.java
@@ -1,0 +1,24 @@
+package com.team05.linkup.domain.user.dto;
+
+import com.team05.linkup.domain.community.dto.CommunityTalentSummaryDTO;
+import com.team05.linkup.domain.mentoring.dto.MatchedMentorProfileDto;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder(toBuilder = true)
+public class ActivityResponseDTO {
+
+    private List<MyPostResponseDTO> posts;
+    private List<MyCommentResponseDTO> comments;
+    private List<MyBookmarkResponseDTO> bookmarks;
+    private List<MyLikeResponseDTO> likes;
+
+    // 멘토 전용
+    private List<CommunityTalentSummaryDTO> talents;
+
+    // 멘티 전용
+    private List<MatchedMentorProfileDto> matches;
+}


### PR DESCRIPTION
## ✨ PR 종류
- [ ] 기능 추가
- [ ] 버그 수정
- [✔️] 리팩토링
- [ ] 문서 수정
- [ ] 기타

---

## 🔨 작업 요약
- 마이페이지 활동 내역 응답 구조를 기존 Map에서 DTO 기반 구조로 리팩토링
- Controller에서 서비스로 역할 분리

---

## 📄 작업 상세
- 작업 1: `Map<String, Object>` → `ActivityResponseDTO`로 변경
- 작업 2: `ProfileService`에 `getCommonActivityDTO()` 메서드 분리
- 작업 3: `ActivityResponseDTO`에 `@Builder(toBuilder = true)` 추가
- 작업 4: `Controller`에서는 역할 분기 및 응답 빌딩만 처리하도록 변경

---

## ✅ 체크리스트
- [✔️] 코드 점검 완료
- [✔️] 테스트 통과
- [✔️] 문서/주석 최신화

---

## 📝 기타

