### PR TITLE
[refactor] 유저 인증 객체 등록

### DIFF
--- a/src/main/java/com/team05/linkup/common/dto/UserPrincipal.java
+++ b/src/main/java/com/team05/linkup/common/dto/UserPrincipal.java
@@ -1,0 +1,10 @@
+package com.team05.linkup.common.dto;
+
+
+public record UserPrincipal(String providerId, String provider) {
+
+    @Override
+    public String toString() {
+        return providerId;
+    }
+}

--- a/src/main/java/com/team05/linkup/common/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/team05/linkup/common/filter/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package com.team05.linkup.common.filter;
 
 
+import com.team05.linkup.common.dto.UserPrincipal;
 import com.team05.linkup.common.util.JwtUtils;
 import io.jsonwebtoken.Claims;
 import io.micrometer.common.lang.NonNullApi;
@@ -49,13 +50,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             Claims claims = jwtUtils.parseToken(token);
             String providerId = claims.getSubject();
             String authorities = (String) claims.get("authorities");
+            String provider = (String) claims.get("provider");
 
             List<SimpleGrantedAuthority> grantedAuthorities = Arrays.stream(authorities.split(","))
                     .map(SimpleGrantedAuthority::new)
                     .collect(Collectors.toList());
 
+            UserPrincipal userPrincipal = new UserPrincipal(providerId, provider);
+
             UsernamePasswordAuthenticationToken authentication =
-                    new UsernamePasswordAuthenticationToken(providerId, token, grantedAuthorities);
+                    new UsernamePasswordAuthenticationToken(userPrincipal, token, grantedAuthorities);
 
             //이 인증 객체를 시큐리티 컨텍스트에 등록하면, 이후 컨트롤러 등에서 @AuthenticationPrincipal을 통해 유저 정보를 가져올 수 있음.
             SecurityContextHolder.getContext().setAuthentication(authentication);
@@ -66,4 +70,3 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
 }
-

--- a/src/main/java/com/team05/linkup/domain/mentoring/api/AiMatchingController.java
+++ b/src/main/java/com/team05/linkup/domain/mentoring/api/AiMatchingController.java
@@ -1,6 +1,7 @@
 package com.team05.linkup.domain.mentoring.api;
 
 import com.team05.linkup.common.dto.ApiResponse;
+import com.team05.linkup.common.dto.UserPrincipal;
 import com.team05.linkup.common.enums.ResponseCode;
 import com.team05.linkup.common.exception.DuplicateMentoringMatchException;
 import com.team05.linkup.common.util.JwtUtils;
@@ -9,7 +10,6 @@ import com.team05.linkup.domain.mentoring.service.AiMatchingListServiceImpl;
 import com.team05.linkup.domain.mentoring.service.AiMatchingSelectorServiceImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -29,25 +29,11 @@ public class AiMatchingController {
     @PreAuthorize("hasAuthority('ROLE_MENTEE')")
     @Operation(description = "ai 매칭 멘토 리스트 결과")
 
-    public ResponseEntity<ApiResponse<AiMatchingResponseDTO>> getRecommendation(HttpServletRequest request,
-                                                                                @AuthenticationPrincipal String providerId) {
+    public ResponseEntity<ApiResponse<AiMatchingResponseDTO>> getRecommendation(@AuthenticationPrincipal UserPrincipal userPrincipal) {
         try {
-            if (providerId == null) {
-                return ResponseEntity
-                        .status(ResponseCode.UNAUTHORIZED.getStatus())
-                        .body(ApiResponse.error(ResponseCode.UNAUTHORIZED));
-            }
-
-            // Extract token and get provider from claims
-            String token = jwtUtils.extractToken(request);
-            if (token == null) {
-                return ResponseEntity
-                        .status(ResponseCode.UNAUTHORIZED.getStatus())
-                        .body(ApiResponse.error(ResponseCode.UNAUTHORIZED));
-            }
-
-            String provider = (String) jwtUtils.parseToken(token).get("provider");
-            if (provider == null) {
+            String providerId = userPrincipal.providerId();
+            String provider = userPrincipal.provider();
+            if (providerId == null || provider == null) {
                 return ResponseEntity
                         .status(ResponseCode.UNAUTHORIZED.getStatus())
                         .body(ApiResponse.error(ResponseCode.UNAUTHORIZED));
@@ -64,32 +50,19 @@ public class AiMatchingController {
     @PostMapping("/{nickname}")
     @Operation(description = "ai 매칭 멘토 선택")
     @PreAuthorize("hasAuthority('ROLE_MENTEE')")
-    public ResponseEntity<ApiResponse> matchMentor(HttpServletRequest request,
-                                                   @PathVariable String nickname,
-                                                   @AuthenticationPrincipal String providerId) {
+    public ResponseEntity<ApiResponse> matchMentor(@PathVariable String nickname,
+                                                   @AuthenticationPrincipal UserPrincipal userPrincipal) {
         try {
-            if (providerId == null) {
+            String providerId = userPrincipal.providerId();
+            String provider = userPrincipal.provider();
+            if (providerId == null || provider == null) {
                 return ResponseEntity
                         .status(ResponseCode.UNAUTHORIZED.getStatus())
                         .body(ApiResponse.error(ResponseCode.UNAUTHORIZED));
             }
 
-            // Extract token and get provider from claims
-            String token = jwtUtils.extractToken(request);
-            if (token == null) {
-                return ResponseEntity
-                        .status(ResponseCode.UNAUTHORIZED.getStatus())
-                        .body(ApiResponse.error(ResponseCode.UNAUTHORIZED));
-            }
-
-            String provider = (String) jwtUtils.parseToken(token).get("provider");
-            if (provider == null) {
-                return ResponseEntity
-                        .status(ResponseCode.UNAUTHORIZED.getStatus())
-                        .body(ApiResponse.error(ResponseCode.UNAUTHORIZED));
-            }
-                    aiMatchingSelectorServiceImpl.matchingMentor(provider, providerId, nickname);
-                    return ResponseEntity.ok(ApiResponse.success());
+            aiMatchingSelectorServiceImpl.matchingMentor(provider, providerId, nickname);
+            return ResponseEntity.ok(ApiResponse.success());
         } catch (DuplicateMentoringMatchException e) {
             return ResponseEntity.ok(ApiResponse.error(ResponseCode.INVALID_INPUT_VALUE));
         }

--- a/src/main/java/com/team05/linkup/domain/mentoring/api/AiMatchingController.java
+++ b/src/main/java/com/team05/linkup/domain/mentoring/api/AiMatchingController.java
@@ -7,13 +7,13 @@ import com.team05.linkup.common.util.JwtUtils;
 import com.team05.linkup.domain.mentoring.dto.AiMatchingResponseDTO;
 import com.team05.linkup.domain.mentoring.service.AiMatchingListServiceImpl;
 import com.team05.linkup.domain.mentoring.service.AiMatchingSelectorServiceImpl;
-import io.jsonwebtoken.Claims;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -28,21 +28,20 @@ public class AiMatchingController {
     @GetMapping("/recommendation")
     @Operation(description = "ai 매칭 멘토 리스트 결과")
 
-    public ResponseEntity<ApiResponse<AiMatchingResponseDTO>> getRecommendation(HttpServletRequest request) {
+    public ResponseEntity<ApiResponse<AiMatchingResponseDTO>> getRecommendation(HttpServletRequest request,
+                                                                                @AuthenticationPrincipal String providerId,
+                                                                                @AuthenticationPrincipal String provider) {
         try {
-            String token = jwtUtils.extractToken(request);
-            if (token != null && !token.isEmpty()) {
-                boolean isValid = jwtUtils.validateToken(token);
-                if (isValid) {
-                    Claims claims = jwtUtils.parseToken(token);
-                    String providerId = claims.getSubject();
-                    String provider = (String) claims.get("provider");
-                    AiMatchingResponseDTO responseDTO = aiMatchingServiceImpl.matchMentor(provider,providerId);
-                    return ResponseEntity.ok(ApiResponse.success(responseDTO));
+                if (providerId == null || provider == null) {
+                    return ResponseEntity
+                            .status(ResponseCode.UNAUTHORIZED.getStatus())
+                            .body(ApiResponse.error(ResponseCode.UNAUTHORIZED));
                 }
-            }
-            return ResponseEntity.ok(ApiResponse.error(ResponseCode.UNAUTHORIZED));
-        } catch (Exception e) {
+                AiMatchingResponseDTO responseDTO = aiMatchingServiceImpl.matchMentor(provider,providerId);
+                return ResponseEntity.ok(ApiResponse.success(responseDTO));
+
+        }
+        catch (Exception e) {
             return ResponseEntity.ok(ApiResponse.error(ResponseCode.INTERNAL_SERVER_ERROR));
         }
     }
@@ -50,20 +49,18 @@ public class AiMatchingController {
     @PostMapping("/{nickname}")
     @Operation(description = "ai 매칭 멘토 선택")
     @PreAuthorize("hasAuthority('ROLE_MENTEE')")
-    public ResponseEntity<ApiResponse> matchMentor(HttpServletRequest request, @PathVariable String nickname) {
+    public ResponseEntity<ApiResponse> matchMentor(HttpServletRequest request,
+                                                   @PathVariable String nickname,
+                                                   @AuthenticationPrincipal String providerId,
+                                                   @AuthenticationPrincipal String provider) {
         try {
-            String token = jwtUtils.extractToken(request);
-            if (token != null && !token.isEmpty()) {
-                boolean valid = jwtUtils.validateToken(token);
-                if (valid) {
-                    Claims claims = jwtUtils.parseToken(token);
-                    String providerId = claims.getSubject();
-                    String provider = (String) claims.get("provider");
+            if (providerId == null || provider == null) {
+                return ResponseEntity
+                        .status(ResponseCode.UNAUTHORIZED.getStatus())
+                        .body(ApiResponse.error(ResponseCode.UNAUTHORIZED));
+                }
                     aiMatchingSelectorServiceImpl.matchingMentor(provider, providerId, nickname);
                     return ResponseEntity.ok(ApiResponse.success());
-                }
-            }
-            return ResponseEntity.ok(ApiResponse.error(ResponseCode.UNAUTHORIZED));
         } catch (DuplicateMentoringMatchException e) {
             return ResponseEntity.ok(ApiResponse.error(ResponseCode.INVALID_INPUT_VALUE));
         }

--- a/src/main/java/com/team05/linkup/domain/user/api/RoleController.java
+++ b/src/main/java/com/team05/linkup/domain/user/api/RoleController.java
@@ -1,13 +1,14 @@
 package com.team05.linkup.domain.user.api;
 
 import com.team05.linkup.common.dto.ApiResponse;
+import com.team05.linkup.common.dto.UserPrincipal;
 import com.team05.linkup.common.enums.ResponseCode;
-import com.team05.linkup.common.util.JwtUtils;
 import com.team05.linkup.domain.user.application.ModifyRoleServiceImpl;
 import com.team05.linkup.domain.user.dto.RoleRequestDTO;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -21,36 +22,31 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/auth")
 public class RoleController {
     private final ModifyRoleServiceImpl modifyRoleServiceImpl;
-    private final JwtUtils jwtUtils;
 
     @PostMapping("/role")
     @PreAuthorize("hasAuthority('ROLE_TEMP')")
-    public ResponseEntity<ApiResponse> modifyRole(HttpServletRequest request,
-                                                  RoleRequestDTO roleRequestDTO,
-                                                  @AuthenticationPrincipal String providerId) {
+    public ResponseEntity<ApiResponse> modifyRole(RoleRequestDTO roleRequestDTO,
+                                                  @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        final Logger logger = LogManager.getLogger(RoleController.class);
+        logger.info("userPrincipal {}", userPrincipal);
         try {
-            if (providerId == null) {
+            if (userPrincipal == null) {
                 return ResponseEntity
                         .status(ResponseCode.UNAUTHORIZED.getStatus())
                         .body(ApiResponse.error(ResponseCode.UNAUTHORIZED));
             }
 
-            // Extract token and get provider from claims
-            String token = jwtUtils.extractToken(request);
-            if (token == null) {
+            String providerId = userPrincipal.providerId();
+            String provider = userPrincipal.provider();
+
+            if (providerId == null || provider == null) {
                 return ResponseEntity
                         .status(ResponseCode.UNAUTHORIZED.getStatus())
                         .body(ApiResponse.error(ResponseCode.UNAUTHORIZED));
             }
 
-            String provider = (String) jwtUtils.parseToken(token).get("provider");
-            if (provider == null) {
-                return ResponseEntity
-                        .status(ResponseCode.UNAUTHORIZED.getStatus())
-                        .body(ApiResponse.error(ResponseCode.UNAUTHORIZED));
-            }
-             modifyRoleServiceImpl.modifyRole(provider, providerId, roleRequestDTO.role());
-                    return ResponseEntity.ok(ApiResponse.success());
+            modifyRoleServiceImpl.modifyRole(provider, providerId, roleRequestDTO.role());
+            return ResponseEntity.ok(ApiResponse.success());
 
         } catch (Exception e) {
             return ResponseEntity.ok(ApiResponse.error(ResponseCode.INTERNAL_SERVER_ERROR));

--- a/src/main/java/com/team05/linkup/domain/user/application/ModifyRoleServiceImpl.java
+++ b/src/main/java/com/team05/linkup/domain/user/application/ModifyRoleServiceImpl.java
@@ -2,6 +2,7 @@ package com.team05.linkup.domain.user.application;
 
 import com.team05.linkup.common.exception.UserNotfoundException;
 import com.team05.linkup.domain.enums.Role;
+import com.team05.linkup.domain.user.domain.User;
 import com.team05.linkup.domain.user.infrastructure.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -19,11 +20,17 @@ public class ModifyRoleServiceImpl implements ModifyRoleService {
     @Override
     public void modifyRole(String provider, String providerId, Role role) throws Exception {
         try {
-            userRepository.updateUserRole(providerId, role);
+            // 사용자 조회
+            User user = userRepository.findByProviderAndProviderId(provider,providerId)
+                    .orElseThrow(() -> new UserNotfoundException("사용자를 찾을 수 없습니다."));
+
+            // ROLE_TEMP 검증
+            if (user.getRole() != Role.ROLE_TEMP) {
+                throw new IllegalStateException("ROLE_TEMP 상태인 사용자만 역할을 변경할 수 있습니다.");
+            }
+
+            userRepository.updateUserRole(user.getId(), role);
             logger.debug("Role updated for user: {}", providerId);
-        } catch (UserNotfoundException e) {
-            logger.error("User not found: {}", e.getMessage());
-            throw new UserNotfoundException("User not found: " + e.getMessage());
         } catch (Exception e) {
             logger.error("Error updating role: {}", e.getMessage());
             throw new Exception("Error updating role: " + e.getMessage(), e);

--- a/src/main/java/com/team05/linkup/domain/user/infrastructure/UserRepository.java
+++ b/src/main/java/com/team05/linkup/domain/user/infrastructure/UserRepository.java
@@ -27,9 +27,9 @@ public interface UserRepository extends JpaRepository<User, String> {
     @Modifying
     @Query("""
                 UPDATE User u SET u.role = :role
-                WHERE u.providerId = :providerId AND u.role = 'ROLE_TEMP'
+                WHERE u.id = :id AND u.role = 'ROLE_TEMP'
           """)
-    void updateUserRole(@Param("providerId") String id, @Param("role") Role role);
+    void updateUserRole(@Param("id") String id, @Param("role") Role role);
 
     @Query("""
         SELECT u.profileTag


### PR DESCRIPTION
## ✨ PR 종류

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 🛠️ 작업 요약

- @AuthenticationPrincipal 개선

## 📝 작업 상세

- 작업 1: 스프링 컨텍스트 홀더에 provider과 providerId를 추가해 UserPrincipal 을 레코드를 생성하고  JwtAuthenticationFilter에 해당 객체값을 등록 하여 캡슐화를 진행했습니다. 이후  @AuthenticationPrincipal 으로 해당 객체값을 들고와 Jwtutil로 claim을 검증하는 작업을 줄여 편의성을 높였습니다.

## ✅ 체크리스트

- [x] 코드 점검 완료
- [x] 테스트 통과
- [x] 문서/주석 최신화

## 📚 기타

- (선택사항)