### PR TITLE
[refactor] UserPrincipal 도입하여 사용자 식별 개선

### DIFF
--- a/src/main/java/com/team05/linkup/domain/community/api/BookmarkController.java
+++ b/src/main/java/com/team05/linkup/domain/community/api/BookmarkController.java
@@ -1,6 +1,7 @@
 package com.team05.linkup.domain.community.api;
 
 import com.team05.linkup.common.dto.ApiResponse;
+import com.team05.linkup.common.dto.UserPrincipal;
 import com.team05.linkup.common.enums.ResponseCode;
 import com.team05.linkup.domain.community.application.BookmarkService;
 import com.team05.linkup.domain.community.dto.BookmarkStatusResponse;
@@ -27,23 +28,25 @@ public class BookmarkController {
      * (북마크 상태 -> 북마크 취소 / 북마크 아닌 상태 -> 북마크 추가)
      *
      * @param communityId 토글할 게시글의 ID (경로 변수).
-     * @param providerId  현재 인증된 사용자 정보 (Spring Security가 주입).
+     * @param userPrincipal  현재 인증된 사용자 정보 (Spring Security가 주입).
      * @return 토글 후의 최종 북마크 상태(bookmarked: true/false)를 담은 응답.
      */
     @Operation(summary = "게시글 북마크 토글", description = "특정 커뮤니티 게시글의 북마크 상태를 변경(토글).")
     @PostMapping("{communityId}/bookmark")
     public ResponseEntity<ApiResponse<BookmarkStatusResponse>> toggleBookmark(
             @PathVariable String communityId,
-            @AuthenticationPrincipal String providerId
+            @AuthenticationPrincipal UserPrincipal userPrincipal
     ) {
-        if (providerId == null) {
+        if (userPrincipal == null) {
             return ResponseEntity
                     .status(ResponseCode.UNAUTHORIZED.getStatus())
                     .body(ApiResponse.error(ResponseCode.UNAUTHORIZED));
         }
+        String provider = userPrincipal.provider();
+        String providerId = userPrincipal.providerId();
 
         // 서비스 호출하여 토글 실행 및 최종 상태 받기
-        boolean isBookmarked = bookmarkService.toggleBookmark(providerId, communityId);
+        boolean isBookmarked = bookmarkService.toggleBookmark(provider, providerId, communityId);
 
         // 성공 응답 반환 (최종 상태 포함)
         return ResponseEntity.ok(ApiResponse.success(new BookmarkStatusResponse(isBookmarked)));

--- a/src/main/java/com/team05/linkup/domain/community/api/LikeController.java
+++ b/src/main/java/com/team05/linkup/domain/community/api/LikeController.java
@@ -1,6 +1,7 @@
 package com.team05.linkup.domain.community.api;
 
 import com.team05.linkup.common.dto.ApiResponse;
+import com.team05.linkup.common.dto.UserPrincipal;
 import com.team05.linkup.common.enums.ResponseCode;
 import com.team05.linkup.domain.community.application.LikeService;
 import com.team05.linkup.domain.community.dto.LikeStatusResponse;
@@ -27,20 +28,25 @@ public class LikeController {
      * (좋아요 상태 -> 좋아요 취소 / 좋아요 아닌 상태 -> 좋아요 추가)
      *
      * @param communityId 토글할 게시글의 ID (경로 변수).
-     * @param providerId  현재 인증된 사용자 정보 (Spring Security가 주입).
+     * @param userPrincipal  현재 인증된 사용자 정보 (Spring Security가 주입).
      * @return 토글 후의 최종 '좋아요' 상태를 담은 응답 (liked: true/false).
      */
     @Operation(summary = "게시글 좋아요 토글", description = "특정 커뮤니티 게시글의 좋아요 상태를 변경(토글)합니다.")
     @PostMapping
     public ResponseEntity<ApiResponse<LikeStatusResponse>> toggleLike(
             @PathVariable String communityId,
-            @AuthenticationPrincipal String providerId
+            @AuthenticationPrincipal UserPrincipal userPrincipal
     ) {
-        if (providerId == null) {
-            return ResponseEntity.status(401).body(ApiResponse.error(ResponseCode.UNAUTHORIZED));
+        if (userPrincipal == null) {
+            return ResponseEntity
+                    .status(ResponseCode.UNAUTHORIZED.getStatus())
+                    .body(ApiResponse.error(ResponseCode.UNAUTHORIZED));
         }
+        String provider = userPrincipal.provider();
+        String providerId = userPrincipal.providerId();
 
-        boolean liked = likeService.toggleLike(providerId, communityId);
+
+        boolean liked = likeService.toggleLike(provider, providerId, communityId);
         return ResponseEntity.ok(ApiResponse.success(new LikeStatusResponse(liked)));
     }
 }

--- a/src/main/java/com/team05/linkup/domain/community/application/BookmarkService.java
+++ b/src/main/java/com/team05/linkup/domain/community/application/BookmarkService.java
@@ -30,16 +30,17 @@ public class BookmarkService {
      * 사용자가 특정 커뮤니티 게시글에 대한 '북마크' 상태를 토글.
      * 이미 북마크 상태이면 취소하고, 아니면 북마크를 추가.
      *
+     * @param provider  토글 요청 사용자 Provider.
      * @param providerId  토글 요청 사용자 Provider ID.
      * @param communityId 대상 게시글 ID.
      * @return 토글 후의 최종 북마크 상태 (true: 북마크됨, false: 북마크 안됨).
      * @throws EntityNotFoundException 사용자 또는 게시글을 찾을 수 없는 경우.
      */
     @Transactional
-    public boolean toggleBookmark(String providerId, String communityId) {
+    public boolean toggleBookmark(String provider, String providerId, String communityId) {
         // 1. 사용자 및 커뮤니티 엔티티 조회
-        User user = userRepository.findByProviderId(providerId)
-                .orElseThrow(() -> new EntityNotFoundException("User not found with PID: " + providerId));
+        User user = userRepository.findByProviderAndProviderId(provider, providerId)
+                .orElseThrow(() -> new EntityNotFoundException("User not found with PID: " + provider + "-" + providerId));
         Community community = communityRepository.findById(communityId)
                 .orElseThrow(() -> new EntityNotFoundException("Community not found with CID: " + communityId));
 

--- a/src/main/java/com/team05/linkup/domain/community/application/LikeService.java
+++ b/src/main/java/com/team05/linkup/domain/community/application/LikeService.java
@@ -30,16 +30,17 @@ public class LikeService {
      * 사용자가 특정 커뮤니티 게시글에 대한 '좋아요' 상태를 토글합니다.
      * 이미 '좋아요' 상태이면 취소하고, 아니면 '좋아요'를 추가합니다.
      *
+     * @param provider  토글 요청 사용자 Provider
      * @param providerId  토글 요청 사용자 Provider ID.
      * @param communityId 대상 게시글 ID.
      * @return 토글 후의 최종 '좋아요' 상태 (true: 좋아요, false: 좋아요 아님).
      * @throws EntityNotFoundException 사용자 또는 게시글을 찾을 수 없는 경우.
      */
     @Transactional //
-    public boolean toggleLike(String providerId, String communityId) {
+    public boolean toggleLike(String provider, String providerId, String communityId) {
         // 1. 사용자 및 커뮤니티 엔티티 조회
-        User user = userRepository.findByProviderId(providerId)
-                .orElseThrow(() -> new EntityNotFoundException("User not found with PID: " + providerId));
+        User user = userRepository.findByProviderAndProviderId(provider, providerId)
+                .orElseThrow(() -> new EntityNotFoundException("User not found with PID: " + provider + "-" + providerId));
         Community community = communityRepository.findById(communityId)
                 .orElseThrow(() -> new EntityNotFoundException("Community not found with CID: " + communityId));
 


### PR DESCRIPTION
## ✨ PR 종류

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 🛠️ 작업 요약

- `@AuthenticationPrincipal`을 통해 주입받는 사용자 정보 객체를 `String`에서 `UserPrincipal`로 변경하여 명확성 및 안정성 개선

## 📝 작업 상세

- **`UserPrincipal` 도입:**

    - 인증된 사용자의 `provider` (e.g., "kakao", "google")와 `providerId`를 함께 가지는 `UserPrincipal` 레코드(또는 DTO)를 정의했습니다.
    - (가정) `JwtAuthenticationFilter` 또는 관련 인증 필터에서 인증 성공 시, `SecurityContextHolder`에 `Authentication` 객체의 `principal`로서 `String` 대신 `UserPrincipal` 객체를 설정하도록 수정했습니다.
    
- **컨트롤러 변경 (`BookmarkController`, `LikeController`):**
    - `@AuthenticationPrincipal String providerId` 대신 `@AuthenticationPrincipal UserPrincipal userPrincipal`을 사용하도록 변경했습니다.
    - 컨트롤러 내부 로직에서 `userPrincipal.provider()` 와 `userPrincipal.providerId()`를 호출하여 필요한 값을 얻도록 수정했습니다.
    
- **서비스 계층 변경 (`BookmarkService`, `LikeService`):**
    - `toggleBookmark`, `toggleLike` 메서드의 파라미터를 `String providerId`에서 `String provider, String providerId`로 변경했습니다.
    - 서비스 내부의 `UserRepository` 호출을 `findByProviderId`에서 `findByProviderAndProviderId`로 변경하여, `provider` 정보까지 활용해 사용자를 정확하게 조회하도록 수정했습니다.
    
- **기대 효과:**
    - 컨트롤러에서 `AuthenticationPrincipal`을 통해 필요한 사용자 식별 정보(`provider`, `providerId`)를 타입 안전하게 직접 얻을 수 있어 코드가 명확해졌습니다.
    - 서비스 계층에서 `provider`와 `providerId`를 모두 사용하여 사용자를 조회하므로, 다른 인증 제공자 간에 `providerId`가 중복될 가능성이 있는 경우에도 안전하게 사용자를 식별할 수 있습니다.
    - 인증 필터에서 `UserPrincipal` 객체 생성을 책임지게 하여, 컨트롤러 레벨에서의 사용자 정보 추출/가공 로직을 줄이고 관심사를 분리했습니다.

## ✅ 체크리스트

- [x] 코드 점검 완료
- [x] (필요시) 관련 테스트 코드 수정 및 통과 확인
- [x] 문서/주석 최신화 (메서드 파라미터 설명 등)

## 📚 기타

- 이 변경으로 인해 향후 다른 기능에서도 인증된 사용자 정보가 필요할 때 일관된 방식으로 `UserPrincipal`을 활용할 수 있습니다.