### PR TITLE
[fix] 프로필 lazy loading 문제(지역/시군구 조회) 해결 및 현재 사용자 식별 로직 정확성 개선

### DIFF
--- a/src/main/java/com/team05/linkup/domain/user/api/ProfileController.java
+++ b/src/main/java/com/team05/linkup/domain/user/api/ProfileController.java
@@ -1,6 +1,7 @@
 package com.team05.linkup.domain.user.api;
 
 import com.team05.linkup.common.dto.ApiResponse;
+import com.team05.linkup.common.dto.UserPrincipal;
 import com.team05.linkup.common.enums.ResponseCode;
 import com.team05.linkup.domain.community.dto.CommunityTalentSummaryDTO;
 import com.team05.linkup.domain.enums.Role;
@@ -17,6 +18,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -39,18 +42,17 @@ public class ProfileController {
 
     @GetMapping("/{nickname}")
     @Transactional(readOnly = true)
-    public ResponseEntity<ApiResponse<ProfilePageDTO>> getProfile(@PathVariable String nickname) {
+    public ResponseEntity<ApiResponse<ProfilePageDTO>> getProfile(@PathVariable String nickname, @AuthenticationPrincipal UserPrincipal userPrincipal) {
 
         Optional<User> userOpt = userRepository.findByNickname(nickname);
         if (userOpt.isEmpty())
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
                     .body(ApiResponse.error(ResponseCode.ENTITY_NOT_FOUND, "프로필을 찾을 수 없습니다."));
 
-        ProfilePageDTO profilePageDTO = profileService.getProfile(userOpt.get());
+        ProfilePageDTO profilePageDTO = profileService.getProfile(userOpt.get(), userPrincipal);
 
         return ResponseEntity.ok(ApiResponse.success(profilePageDTO));
     }
-
 
     @GetMapping("/{nickname}/activity")
     public ResponseEntity<ApiResponse<ActivityResponseDTO>> getActivity(@PathVariable String nickname) {

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -61,3 +61,7 @@ logging:
 jwt:
   secret: ${JWT_SECRET}
   expiration: 3600000
+
+api:
+  Key:
+    gemini: ${GEMINI_API_KEY}


### PR DESCRIPTION
## ✨ PR 종류

- [ ] 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 🛠️ 작업 요약
- `isCurrentUser` 로직을 **provider와 providerId를 함께 비교**하도록 수정하여 정확한 사용자 확인
   <img width="400" alt="사용자 provider, providerId 비교" src="https://github.com/user-attachments/assets/d5e90b76-d7ef-4d71-b664-accd892a5662" />

- **레이지 로딩 문제 해결**: `area`와 `sigungu` 데이터를 조회할 때 레이지 로딩으로 인한 성능 이슈 해결
   <img width="400" alt="프로필 조회" src="https://github.com/user-attachments/assets/4bf30cb1-b9e9-4281-8d57-5dade8126158" />


## 📝 작업 상세
- **`isCurrentUser` 로직 개선**: 
  - 사용자의 **provider**와 **providerId**를 비교하여 현재 사용자와 일치하는지 확인하도록 수정했습니다. 이전에는 `providerId`만 비교했지만, 이제는 `provider`와 `providerId` 두 값을 함께 비교하여 더 정확한 일치 여부를 확인할 수 있습니다. 이를 통해 보안과 정확성을 강화하였습니다.

- **`@AuthenticationPrincipal`을 사용하여 로그인한 사용자 정보 조회**:
  - **`ProfileController`** 에서 `getProfile` 메소드에 **`@AuthenticationPrincipal`** 을 추가하여 현재 로그인한 사용자의 정보를 **`userPrincipal`** 로 받아오도록 수정하였습니다.
  
- **트랜잭셔널 적용**:
  - `getProfile` 메소드에 `@Transactional(readOnly = true)`를 적용하여 **`area`와 `sigungu` 데이터 조회 시 레이지 로딩 이슈**를 해결했습니다.

## ✅ 체크리스트

- [x] 코드 점검 완료
- [x] 테스트 통과
- [x] 문서/주석 최신화

## 📚 기타

### 테스트
- 멘토/멘티 프로필 정상 조회 확인
- 로그인한 사용자가 자신의 프로필을 조회할 때 `isCurrentUser`가 true로 반환되는지 확인
- 시/군/구 정보가 정확하게 조회되는지 확인 완료

