### PR TITLE
[feat] 멘티 리뷰 관련 CRUD 기능 구현

### DIFF
--- a/src/main/generated/com/team05/linkup/domain/review/domain/QReview.java
+++ b/src/main/generated/com/team05/linkup/domain/review/domain/QReview.java
@@ -1,0 +1,55 @@
+package com.team05.linkup.domain.review.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QReview is a Querydsl query type for Review
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QReview extends EntityPathBase<Review> {
+
+    private static final long serialVersionUID = 1153348732L;
+
+    public static final QReview review = new QReview("review");
+
+    public final com.team05.linkup.domain.baseEntity.QBaseEntity _super = new com.team05.linkup.domain.baseEntity.QBaseEntity(this);
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.ZonedDateTime> createdAt = _super.createdAt;
+
+    public final StringPath id = createString("id");
+
+    public final EnumPath<com.team05.linkup.domain.enums.Interest> interest = createEnum("interest", com.team05.linkup.domain.enums.Interest.class);
+
+    public final StringPath mentoringSessionId = createString("mentoringSessionId");
+
+    public final NumberPath<java.math.BigDecimal> star = createNumber("star", java.math.BigDecimal.class);
+
+    public final StringPath title = createString("title");
+
+    //inherited
+    public final DateTimePath<java.time.ZonedDateTime> updatedAt = _super.updatedAt;
+
+    public QReview(String variable) {
+        super(Review.class, forVariable(variable));
+    }
+
+    public QReview(Path<? extends Review> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QReview(PathMetadata metadata) {
+        super(Review.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/team05/linkup/domain/user/dto/QCommunityQnAPostDTO.java
+++ b/src/main/generated/com/team05/linkup/domain/user/dto/QCommunityQnAPostDTO.java
@@ -1,0 +1,21 @@
+package com.team05.linkup.domain.user.dto;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.ConstructorExpression;
+import javax.annotation.processing.Generated;
+
+/**
+ * com.team05.linkup.domain.user.dto.QCommunityQnAPostDTO is a Querydsl Projection type for CommunityQnAPostDTO
+ */
+@Generated("com.querydsl.codegen.DefaultProjectionSerializer")
+public class QCommunityQnAPostDTO extends ConstructorExpression<CommunityQnAPostDTO> {
+
+    private static final long serialVersionUID = 1245288546L;
+
+    public QCommunityQnAPostDTO(com.querydsl.core.types.Expression<String> postId, com.querydsl.core.types.Expression<String> nickname, com.querydsl.core.types.Expression<String> profileImageUrl, com.querydsl.core.types.Expression<String> createdAt, com.querydsl.core.types.Expression<String> title, com.querydsl.core.types.Expression<String> content, com.querydsl.core.types.Expression<String> tagName, com.querydsl.core.types.Expression<Integer> commentCount) {
+        super(CommunityQnAPostDTO.class, new Class<?>[]{String.class, String.class, String.class, String.class, String.class, String.class, String.class, int.class}, postId, nickname, profileImageUrl, createdAt, title, content, tagName, commentCount);
+    }
+
+}
+

--- a/src/main/java/com/team05/linkup/common/enums/ResponseCode.java
+++ b/src/main/java/com/team05/linkup/common/enums/ResponseCode.java
@@ -26,7 +26,12 @@ public enum ResponseCode {
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 댓글을 찾을 수 없습니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 카테고리를 찾을 수 없습니다."),
     NO_EDIT_PERMISSION(HttpStatus.FORBIDDEN, "수정 권한이 없습니다."),
-    NO_DELETE_PERMISSION(HttpStatus.FORBIDDEN, "삭제 권한이 없습니다.");
+    NO_DELETE_PERMISSION(HttpStatus.FORBIDDEN, "삭제 권한이 없습니다."),
+
+    // 리뷰 관련 오류
+    CONFLICT(HttpStatus.CONFLICT, "이미 존재하는 리소스입니다."),
+    INVALID_MENTORING_SESSION(HttpStatus.BAD_REQUEST, "유효하지 않은 멘토링 세션입니다.");
+
 
     // 추가적인 도메인별 에러 코드 정의 가능
 

--- a/src/main/java/com/team05/linkup/domain/mentoring/domain/MentoringSessions.java
+++ b/src/main/java/com/team05/linkup/domain/mentoring/domain/MentoringSessions.java
@@ -8,6 +8,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
+@Table(name = "mentoring_sessions")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/team05/linkup/domain/mentoring/domain/Review.java
+++ b/src/main/java/com/team05/linkup/domain/mentoring/domain/Review.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 import java.math.BigDecimal;
 
 //@Entity
-@Table(name = "review")
+//@Table(name = "review")
 @Getter
 @NoArgsConstructor
 public class Review extends BaseEntity {

--- a/src/main/java/com/team05/linkup/domain/mentoring/domain/Review.java
+++ b/src/main/java/com/team05/linkup/domain/mentoring/domain/Review.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 
-@Entity
+//@Entity
 @Table(name = "review")
 @Getter
 @NoArgsConstructor

--- a/src/main/java/com/team05/linkup/domain/mentoring/infrastructure/MentoringRepository.java
+++ b/src/main/java/com/team05/linkup/domain/mentoring/infrastructure/MentoringRepository.java
@@ -18,4 +18,7 @@ public interface MentoringRepository extends JpaRepository<MentoringSessions, St
 
     @Query(value = "SELECT * FROM mentoring_sessions WHERE id = :id", nativeQuery = true)
     Optional<MentoringSessions> findMentoringSessionById(@org.springframework.data.repository.query.Param("id") String id);
+
+    @Query("SELECT m FROM MentoringSessions m JOIN FETCH m.mentor JOIN FETCH m.mentee WHERE m.mentee.id = :menteeId")
+    List<MentoringSessions> findByMenteeIdWithMentorAndMentee(@Param("menteeId") String menteeId);
 }

--- a/src/main/java/com/team05/linkup/domain/mentoring/infrastructure/MentoringRepository.java
+++ b/src/main/java/com/team05/linkup/domain/mentoring/infrastructure/MentoringRepository.java
@@ -15,4 +15,7 @@ public interface MentoringRepository extends JpaRepository<MentoringSessions, St
 
     @Query("SELECT m FROM MentoringSessions m WHERE m.mentee.id = :menteeId AND m.status = :status")
     List<MentoringSessions> findByMenteeIdAndStatus(@Param("menteeId") String menteeId, @Param("status") MentoringStatus status);
+
+    @Query(value = "SELECT * FROM mentoring_sessions WHERE id = :id", nativeQuery = true)
+    Optional<MentoringSessions> findMentoringSessionById(@org.springframework.data.repository.query.Param("id") String id);
 }

--- a/src/main/java/com/team05/linkup/domain/mentoring/infrastructure/MentoringRepository.java
+++ b/src/main/java/com/team05/linkup/domain/mentoring/infrastructure/MentoringRepository.java
@@ -1,5 +1,6 @@
 package com.team05.linkup.domain.mentoring.infrastructure;
 
+import com.team05.linkup.domain.enums.MentoringStatus;
 import com.team05.linkup.domain.mentoring.domain.MentoringSessions;
 import org.apache.ibatis.annotations.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +12,7 @@ import java.util.Optional;
 public interface MentoringRepository extends JpaRepository<MentoringSessions, String> {
     @Query(value = "SELECT * FROM mentoring_sessions WHERE mentee_user_id = :userId ORDER BY created_at DESC LIMIT :limit", nativeQuery = true)
     List<MentoringSessions> findByMenteeUserIdWithLimit(@Param("userId") String userId, @Param("limit") int limit);
+
+    @Query("SELECT m FROM MentoringSessions m WHERE m.mentee.id = :menteeId AND m.status = :status")
+    List<MentoringSessions> findByMenteeIdAndStatus(@Param("menteeId") String menteeId, @Param("status") MentoringStatus status);
 }

--- a/src/main/java/com/team05/linkup/domain/review/api/MenteeReviewController.java
+++ b/src/main/java/com/team05/linkup/domain/review/api/MenteeReviewController.java
@@ -88,4 +88,30 @@ public class MenteeReviewController {
                     .body(ApiResponse.error(ResponseCode.ACCESS_DENIED, e.getMessage()));
         }
     }
+
+    @PatchMapping("/review/{reviewId}")
+    public ResponseEntity<ApiResponse> updateReview(@AuthenticationPrincipal UserPrincipal userPrincipal, @PathVariable String reviewId,@RequestBody ReviewRequestDTO reviewRequestDTO) {
+        Optional<User> userOpt = userRepository.findByProviderAndProviderId(
+                userPrincipal.provider(), userPrincipal.providerId());
+        if (userOpt.isEmpty())
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(ApiResponse.error(ResponseCode.ENTITY_NOT_FOUND, "프로필을 찾을 수 없습니다."));
+
+        try {
+            reviewService.updateReview(userOpt.get(), reviewId, reviewRequestDTO);
+            return ResponseEntity.ok(ApiResponse.created("리뷰가 성공적으로 수정되었습니다."));
+        } catch (ConstraintViolationException ex) {
+            // 유효성 검증 실패 처리
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(ApiResponse.error(ResponseCode.INVALID_INPUT_VALUE, ex.getMessage()));
+        } catch (IllegalStateException ex) {
+            // 권한이 없을 때 (FORBIDDEN)
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(ApiResponse.error(ResponseCode.ACCESS_DENIED, ex.getMessage()));
+        } catch (IllegalArgumentException ex) {
+            // 잘못된 요청 데이터 또는 멘토링 세션 문제 (BAD_REQUEST)
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(ApiResponse.error(ResponseCode.INVALID_MENTORING_SESSION, ex.getMessage()));
+        }
+    }
 }

--- a/src/main/java/com/team05/linkup/domain/review/api/MenteeReviewController.java
+++ b/src/main/java/com/team05/linkup/domain/review/api/MenteeReviewController.java
@@ -136,4 +136,22 @@ public class MenteeReviewController {
                     .body(ApiResponse.error(ResponseCode.ENTITY_NOT_FOUND, ex.getMessage()));
         }
     }
+
+    @GetMapping("/review/list/{nickname}")
+    public ResponseEntity<ApiResponse<List<ReviewResponseDTO>>> getReviewHistory(@AuthenticationPrincipal UserPrincipal userPrincipal, @PathVariable String nickname) {
+        Optional<User> userOpt = userRepository.findByProviderAndProviderId(
+                userPrincipal.provider(), userPrincipal.providerId());
+        if (userOpt.isEmpty())
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(ApiResponse.error(ResponseCode.ENTITY_NOT_FOUND, "프로필을 찾을 수 없습니다."));
+
+        try {
+            List<ReviewResponseDTO> reviews = reviewService.getReviewHistory(userOpt.get(), userPrincipal);
+            return ResponseEntity.ok(ApiResponse.success(reviews));
+        } catch (IllegalArgumentException e) {
+            // 리뷰 조회 권환이 업을 때
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(ApiResponse.error(ResponseCode.ACCESS_DENIED, e.getMessage()));
+        }
+    }
 }

--- a/src/main/java/com/team05/linkup/domain/review/api/MenteeReviewController.java
+++ b/src/main/java/com/team05/linkup/domain/review/api/MenteeReviewController.java
@@ -1,0 +1,41 @@
+package com.team05.linkup.domain.review.api;
+
+import com.team05.linkup.common.dto.ApiResponse;
+import com.team05.linkup.common.dto.UserPrincipal;
+import com.team05.linkup.common.enums.ResponseCode;
+import com.team05.linkup.domain.review.application.ReviewService;
+import com.team05.linkup.domain.review.dto.MyCompletedMentoringDTO;
+import com.team05.linkup.domain.user.domain.User;
+import com.team05.linkup.domain.user.dto.ProfilePageDTO;
+import com.team05.linkup.domain.user.infrastructure.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/v1/mentee")
+@RequiredArgsConstructor
+public class MenteeReviewController {
+    private static final Logger logger = LogManager.getLogger();
+    private final ReviewService reviewService;
+    private final UserRepository userRepository;
+
+    @GetMapping("/review")
+    public ResponseEntity<ApiResponse<List<MyCompletedMentoringDTO>>> getCompletedMentoringSessions(@AuthenticationPrincipal UserPrincipal userPrincipal) {
+        Optional<User> userOpt = userRepository.findByProviderAndProviderId(
+                userPrincipal.provider(), userPrincipal.providerId());
+        if (userOpt.isEmpty())
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(ApiResponse.error(ResponseCode.ENTITY_NOT_FOUND, "프로필을 찾을 수 없습니다."));
+
+        List<MyCompletedMentoringDTO> result = reviewService.getCompletedMentoringSessions(userOpt.get());
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+}

--- a/src/main/java/com/team05/linkup/domain/review/api/MenteeReviewController.java
+++ b/src/main/java/com/team05/linkup/domain/review/api/MenteeReviewController.java
@@ -5,9 +5,10 @@ import com.team05.linkup.common.dto.UserPrincipal;
 import com.team05.linkup.common.enums.ResponseCode;
 import com.team05.linkup.domain.review.application.ReviewService;
 import com.team05.linkup.domain.review.dto.MyCompletedMentoringDTO;
+import com.team05.linkup.domain.review.dto.ReviewRequestDTO;
 import com.team05.linkup.domain.user.domain.User;
-import com.team05.linkup.domain.user.dto.ProfilePageDTO;
 import com.team05.linkup.domain.user.infrastructure.UserRepository;
+import jakarta.validation.ConstraintViolationException;
 import lombok.RequiredArgsConstructor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -37,5 +38,31 @@ public class MenteeReviewController {
 
         List<MyCompletedMentoringDTO> result = reviewService.getCompletedMentoringSessions(userOpt.get());
         return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @PostMapping("/review")
+    public ResponseEntity<ApiResponse> createReview(@AuthenticationPrincipal UserPrincipal userPrincipal, @RequestBody ReviewRequestDTO reviewRequestDTO) {
+        Optional<User> userOpt = userRepository.findByProviderAndProviderId(
+                userPrincipal.provider(), userPrincipal.providerId());
+        if (userOpt.isEmpty())
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(ApiResponse.error(ResponseCode.ENTITY_NOT_FOUND, "프로필을 찾을 수 없습니다."));
+
+        try {
+            reviewService.createReview(reviewRequestDTO);
+            return ResponseEntity.ok(ApiResponse.created("리뷰가 성공적으로 생성되었습니다."));
+        } catch (ConstraintViolationException ex) {
+            // 유효성 검증 실패 처리
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(ApiResponse.error(ResponseCode.INVALID_INPUT_VALUE, ex.getMessage()));
+        } catch (IllegalStateException ex) {
+            // 이미 리뷰가 존재하는 경우 (CONFLICT)
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(ApiResponse.error(ResponseCode.CONFLICT, ex.getMessage()));
+        } catch (IllegalArgumentException ex) {
+            // 멘토링 세션이 완료되지 않은 경우 (BAD_REQUEST)
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(ApiResponse.error(ResponseCode.INVALID_MENTORING_SESSION, ex.getMessage()));
+        }
     }
 }

--- a/src/main/java/com/team05/linkup/domain/review/api/MenteeReviewController.java
+++ b/src/main/java/com/team05/linkup/domain/review/api/MenteeReviewController.java
@@ -114,4 +114,26 @@ public class MenteeReviewController {
                     .body(ApiResponse.error(ResponseCode.INVALID_MENTORING_SESSION, ex.getMessage()));
         }
     }
+
+    @DeleteMapping("/review/{reviewId}")
+    public ResponseEntity<ApiResponse> deleteReview(@AuthenticationPrincipal UserPrincipal userPrincipal, @PathVariable String reviewId) {
+        Optional<User> userOpt = userRepository.findByProviderAndProviderId(
+                userPrincipal.provider(), userPrincipal.providerId());
+        if (userOpt.isEmpty())
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(ApiResponse.error(ResponseCode.ENTITY_NOT_FOUND, "프로필을 찾을 수 없습니다."));
+
+        try {
+            reviewService.deleteReview(userOpt.get(), reviewId);
+            return ResponseEntity.ok(ApiResponse.success("리뷰가 성공적으로 삭제되었습니다."));
+        } catch (IllegalStateException ex) {
+            // 권한이 없을 때 (FORBIDDEN)
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(ApiResponse.error(ResponseCode.ACCESS_DENIED, ex.getMessage()));
+        } catch (IllegalArgumentException ex) {
+            // 리뷰를 찾을 수 없거나 잘못된 요청일 때 (BAD_REQUEST)
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(ApiResponse.error(ResponseCode.ENTITY_NOT_FOUND, ex.getMessage()));
+        }
+    }
 }

--- a/src/main/java/com/team05/linkup/domain/review/application/ReviewService.java
+++ b/src/main/java/com/team05/linkup/domain/review/application/ReviewService.java
@@ -1,0 +1,42 @@
+package com.team05.linkup.domain.review.application;
+
+import com.team05.linkup.domain.enums.MentoringStatus;
+import com.team05.linkup.domain.mentoring.domain.MentoringSessions;
+import com.team05.linkup.domain.mentoring.infrastructure.MentoringRepository;
+import com.team05.linkup.domain.review.dto.MyCompletedMentoringDTO;
+import com.team05.linkup.domain.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+
+    private static final Logger logger = LogManager.getLogger();
+    private final MentoringRepository mentoringRepository;
+
+    public List<MyCompletedMentoringDTO> getCompletedMentoringSessions(User user) {
+
+        // userId와 상태가 COMPLETED인 멘토링 세션 조회
+        List<MentoringSessions> completedSessions = mentoringRepository.findByMenteeIdAndStatus(user.getId(), MentoringStatus.COMPLETED);
+
+        logger.debug(completedSessions);
+        completedSessions.forEach(session -> {
+            logger.debug("Mentoring Session ID: " + session.getId());
+            logger.debug("Mentor Name: " + session.getMentor().getName());
+        });
+
+        // DTO로 변환
+        return completedSessions.stream()
+                .map(session -> MyCompletedMentoringDTO.builder()
+                        .sessionId(session.getId())
+                        .mentorName(session.getMentor().getName())
+                        .build())
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/team05/linkup/domain/review/application/ReviewService.java
+++ b/src/main/java/com/team05/linkup/domain/review/application/ReviewService.java
@@ -3,14 +3,22 @@ package com.team05.linkup.domain.review.application;
 import com.team05.linkup.domain.enums.MentoringStatus;
 import com.team05.linkup.domain.mentoring.domain.MentoringSessions;
 import com.team05.linkup.domain.mentoring.infrastructure.MentoringRepository;
+import com.team05.linkup.domain.review.domain.Review;
 import com.team05.linkup.domain.review.dto.MyCompletedMentoringDTO;
+import com.team05.linkup.domain.review.dto.ReviewRequestDTO;
+import com.team05.linkup.domain.review.infrastructure.ReviewRepository;
 import com.team05.linkup.domain.user.domain.User;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
 import lombok.RequiredArgsConstructor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
+import jakarta.validation.Validator;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -19,6 +27,8 @@ public class ReviewService {
 
     private static final Logger logger = LogManager.getLogger();
     private final MentoringRepository mentoringRepository;
+    private final ReviewRepository reviewRepository;
+    private final Validator validator;
 
     public List<MyCompletedMentoringDTO> getCompletedMentoringSessions(User user) {
 
@@ -38,5 +48,38 @@ public class ReviewService {
                         .mentorName(session.getMentor().getName())
                         .build())
                 .collect(Collectors.toList());
+    }
+
+    public void createReview(ReviewRequestDTO reviewRequestDTO) {
+        // 1. 리뷰 중복 검증
+        Optional<Review> existingReview = reviewRepository.findById(reviewRequestDTO.getMentoringSessionId());
+        if (existingReview.isPresent()) {
+            throw new IllegalStateException("이 세션에 대한 리뷰는 이미 존재합니다.");
+        }
+
+        // 2. 멘토링 세션 완료 상태 검증
+        Optional<MentoringSessions> session = mentoringRepository.findMentoringSessionById(reviewRequestDTO.getMentoringSessionId());
+        logger.debug(reviewRequestDTO.getMentoringSessionId());
+        if (session.isEmpty() || session.get().getStatus() != MentoringStatus.COMPLETED) {
+            logger.debug(session.get().getStatus());
+            logger.debug(MentoringStatus.COMPLETED);
+            // 멘토링 세션이 완료되지 않았다면 400 Bad Request 에러를 반환
+            throw new IllegalArgumentException("해당 멘토링 세션은 완료되지 않았습니다.");
+        }
+
+        // 3. 리뷰 객체 생성
+        Review review = reviewRequestDTO.toEntity(reviewRequestDTO);
+
+        // 4. 유효성 검사 수행 (Bean Validation 수동 호출)
+        Set<ConstraintViolation<Review>> violations = validator.validate(review);
+        if (!violations.isEmpty()) {
+            // 첫 번째 유효성 위반 메시지를 추출
+            String message = violations.iterator().next().getMessage();
+            // ConstraintViolationException 발생 (Spring @ExceptionHandler로 잡아 응답 처리 가능)
+            throw new ConstraintViolationException(message, violations);
+        }
+
+        // 5. 검증 통과 시 저장
+        reviewRepository.save(review);
     }
 }

--- a/src/main/java/com/team05/linkup/domain/review/application/ReviewService.java
+++ b/src/main/java/com/team05/linkup/domain/review/application/ReviewService.java
@@ -142,4 +142,22 @@ public class ReviewService {
 
         reviewRepository.save(updatedReview);
     }
+
+    public void deleteReview(User user, String reviewId) {
+        // 1. 리뷰 존재 여부 확인
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new IllegalArgumentException("리뷰를 찾을 수 없습니다."));
+
+        // 2. 멘토링 세션 조회
+        MentoringSessions session = mentoringRepository.findMentoringSessionById(review.getMentoringSessionId())
+                .orElseThrow(() -> new IllegalArgumentException("멘토링 세션을 찾을 수 없습니다."));
+
+        // 3. 권한 확인
+        if (!session.getMentee().getId().equals(user.getId())) {
+            throw new IllegalStateException("리뷰 삭제 권한이 없습니다.");
+        }
+
+        // 4. 리뷰 삭제
+        reviewRepository.delete(review);
+    }
 }

--- a/src/main/java/com/team05/linkup/domain/review/domain/Review.java
+++ b/src/main/java/com/team05/linkup/domain/review/domain/Review.java
@@ -11,6 +11,7 @@ import lombok.*;
 import java.math.BigDecimal;
 
 @Entity
+@Table(name = "review")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/team05/linkup/domain/review/domain/Review.java
+++ b/src/main/java/com/team05/linkup/domain/review/domain/Review.java
@@ -1,0 +1,43 @@
+package com.team05.linkup.domain.review.domain;
+
+import com.team05.linkup.domain.baseEntity.BaseEntity;
+import com.team05.linkup.domain.enums.*;
+import com.team05.linkup.domain.user.domain.User;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class Review extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;  // 리뷰 ID (UUID)
+
+    @Column(nullable = false, length = 36)
+    private String mentoringSessionId;  // 멘토링 세션 ID (ID만 저장)
+
+    @Column(nullable = false, length = 100)
+    private String title;  // 리뷰 제목
+
+    @Column(nullable = false, columnDefinition = "LONGTEXT")
+    private String content;  // 리뷰 내용
+
+    @Column(nullable = false, precision = 2, scale = 1)
+    @DecimalMin(value = "0.0", inclusive = true)
+    @DecimalMax(value = "5.0", inclusive = true)
+    private BigDecimal star; // 리뷰 별점 (0.0 ~ 5.0)
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Interest interest;
+
+
+}

--- a/src/main/java/com/team05/linkup/domain/review/dto/MyCompletedMentoringDTO.java
+++ b/src/main/java/com/team05/linkup/domain/review/dto/MyCompletedMentoringDTO.java
@@ -1,0 +1,11 @@
+package com.team05.linkup.domain.review.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MyCompletedMentoringDTO {
+    private String sessionId;
+    private String mentorName;
+}

--- a/src/main/java/com/team05/linkup/domain/review/dto/ReviewRequestDTO.java
+++ b/src/main/java/com/team05/linkup/domain/review/dto/ReviewRequestDTO.java
@@ -1,0 +1,38 @@
+package com.team05.linkup.domain.review.dto;
+
+import com.team05.linkup.domain.enums.Interest;
+import com.team05.linkup.domain.review.domain.Review;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+public class ReviewRequestDTO {
+
+    private String mentoringSessionId;  // 멘토링 세션 ID
+
+    private String title;  // 리뷰 제목
+
+    private String content;  // 리뷰 내용
+
+    @DecimalMin(value = "0.0", inclusive = true)   // 별점 최소값 (0.0 이상)
+    @DecimalMax(value = "5.0", inclusive = true)   // 별점 최대값 (5.0 이하)
+    private BigDecimal star;  // 리뷰 별점 (0.0 ~ 5.0)
+
+    private Interest interest;  // 관심사 (ENUM)
+
+    // 생성된 DTO 객체에서 엔티티로 변환할 수 있는 메소드
+    public static Review toEntity(ReviewRequestDTO dto) {
+        return Review.builder()
+                .mentoringSessionId(dto.getMentoringSessionId())
+                .title(dto.getTitle())
+                .content(dto.getContent())
+                .star(dto.getStar())
+                .interest(dto.getInterest())
+                .build();
+    }
+}

--- a/src/main/java/com/team05/linkup/domain/review/dto/ReviewResponseDTO.java
+++ b/src/main/java/com/team05/linkup/domain/review/dto/ReviewResponseDTO.java
@@ -1,0 +1,36 @@
+package com.team05.linkup.domain.review.dto;
+
+import com.team05.linkup.domain.enums.Interest;
+import com.team05.linkup.domain.review.domain.Review;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+public class ReviewResponseDTO {
+
+    private String mentoringSessionId;  // 멘토링 세션 ID
+
+    private String title;  // 리뷰 제목
+
+    private String content;  // 리뷰 내용
+
+    private BigDecimal star;  // 리뷰 별점 (0.0 ~ 5.0)
+
+    private Interest interest;  // 관심사 (ENUM)
+
+    // 생성된 DTO 객체에서 엔티티로 변환할 수 있는 메소드
+    public static Review toEntity(ReviewResponseDTO dto) {
+        return Review.builder()
+                .mentoringSessionId(dto.getMentoringSessionId())
+                .title(dto.getTitle())
+                .content(dto.getContent())
+                .star(dto.getStar())
+                .interest(dto.getInterest())
+                .build();
+    }
+}

--- a/src/main/java/com/team05/linkup/domain/review/infrastructure/ReviewRepository.java
+++ b/src/main/java/com/team05/linkup/domain/review/infrastructure/ReviewRepository.java
@@ -33,4 +33,7 @@ public interface ReviewRepository extends JpaRepository<Review, String> {
             @Param("mentorId") String mentorId,
             @Param("limit") int limit
     );
+
+    @Query("SELECT r FROM Review r WHERE r.mentoringSessionId IN :sessionIds")
+    List<Review> findByMentoringSessionIdIn(@Param("sessionIds") List<String> sessionIds);
 }

--- a/src/main/java/com/team05/linkup/domain/review/infrastructure/ReviewRepository.java
+++ b/src/main/java/com/team05/linkup/domain/review/infrastructure/ReviewRepository.java
@@ -1,14 +1,15 @@
-package com.team05.linkup.domain.mentoring.infrastructure;
+package com.team05.linkup.domain.review.infrastructure;
 
-import com.team05.linkup.domain.mentoring.domain.Review;
+import com.team05.linkup.domain.review.domain.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+@Repository
 public interface ReviewRepository extends JpaRepository<Review, String> {
-
     @Query(value = """
         SELECT 
             u.name AS reviewer_name,

--- a/src/main/java/com/team05/linkup/domain/user/application/ProfileService.java
+++ b/src/main/java/com/team05/linkup/domain/user/application/ProfileService.java
@@ -3,7 +3,7 @@ package com.team05.linkup.domain.user.application;
 import com.team05.linkup.common.dto.UserPrincipal;
 import com.team05.linkup.domain.community.infrastructure.CommunityRepository;
 import com.team05.linkup.domain.mentoring.dto.ReceivedReviewDTO;
-import com.team05.linkup.domain.mentoring.infrastructure.ReviewRepository;
+import com.team05.linkup.domain.review.infrastructure.ReviewRepository;
 import com.team05.linkup.domain.user.domain.Area;
 import com.team05.linkup.domain.user.domain.Sigungu;
 import com.team05.linkup.domain.user.domain.User;

--- a/src/main/java/com/team05/linkup/domain/user/application/ProfileService.java
+++ b/src/main/java/com/team05/linkup/domain/user/application/ProfileService.java
@@ -61,7 +61,7 @@ public class ProfileService {
                 .build();
     }
 
-    private static boolean isCurrentUser(User user, UserPrincipal userPrincipal) {
+    public static boolean isCurrentUser(User user, UserPrincipal userPrincipal) {
         if (userPrincipal == null) {
             return false;
         }


### PR DESCRIPTION
## ✨ PR 종류 검증

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 🛠️ 작업 요약

- 멘티 사용자가 **작성 가능한 멘토링 세션 목록을 조회**하는 기능 추가
- 멘티 리뷰 **작성** 기능 추가 (멘토링 세션 완료 및 리뷰 중복 등 검증 포함)
- 기존 리뷰 정보를 **수정하기 위해 조회**하는 기능 추가 (소유권 확인 포함)
- 작성된 멘티 리뷰를 **수정**하는 기능 추가 (소유권 및 유효성 검증 포함)
- 작성된 멘티 리뷰를 **삭제**하는 기능 추가 (소유권 확인 포함)
- 특정 사용자의 멘티 **리뷰 내역을 조회**하는 기능 추가 (조회 권한 확인 포함)
- `isCurrentUser` 로직을 개선하고 공용화하여 **provider와 providerId를 함께 비교**하도록 수정, 리뷰 내역 조회 시 활용

## 📝 작업 상세

### 멘티 리뷰 기능 구현 (CRUD 및 조회)

#### 작성 대상 멘토링 세션 조회
- **API**: `GET /v1/mentee/review`
- **기능**: 로그인 멘티의 `COMPLETED` 상태 멘토링 세션 목록 조회
- **구현**: `MentoringRepository`에 `findByMenteeIdAndStatus` 쿼리 메소드 추가
- **응답**: `MyCompletedMentoringDTO`로 세션 ID와 멘토 이름 반환

#### 리뷰 작성
- **API**: `POST /v1/mentee/review`
- **요청**: `ReviewRequestDTO` (세션ID, 제목, 내용, 별점(0.0~5.0), 관심사)
- **검증**:
  - 리뷰 중복 검증
  - 멘토링 세션 완료 상태 검증
  - Bean Validation을 통한 유효성 검사
- **오류 처리**:
  - 유효성 위반: `BAD_REQUEST`, `INVALID_INPUT_VALUE`
  - 중복 리뷰: `CONFLICT`
  - 무효한 세션: `BAD_REQUEST`, `INVALID_MENTORING_SESSION`

#### 리뷰 조회 (수정용)
- **API**: `GET /v1/mentee/review/{reviewId}`
- **검증**: 리뷰 존재 확인 및 현재 사용자 소유권 확인
- **응답**: `ReviewResponseDTO`로 리뷰 정보 반환
- **오류 처리**:
  - 리뷰/세션 없음: `BAD_REQUEST`, `ENTITY_NOT_FOUND`
  - 권한 없음: `FORBIDDEN`, `ACCESS_DENIED`

#### 리뷰 수정
- **API**: `PATCH /v1/mentee/review/{reviewId}`
- **요청**: `ReviewRequestDTO` (세션ID, 제목, 내용, 별점(0.0~5.0), 관심사)
- **검증**: 리뷰 존재 확인, 소유권 확인, 유효성 검사
- **구현**: 기존 리뷰의 ID 유지하면서 내용 업데이트
- **오류 처리**:
  - 유효성 위반: `BAD_REQUEST`, `INVALID_INPUT_VALUE`
  - 권한 없음: `FORBIDDEN`, `ACCESS_DENIED`
  - 리뷰/세션 없음: `BAD_REQUEST`, `INVALID_MENTORING_SESSION`

#### 리뷰 삭제
- **API**: `POST /v1/mentee/review/{reviewId}` (주의: HTTP 메소드가 POST)
- **검증**: 리뷰 존재 확인 및 소유권 확인
- **오류 처리**:
  - 권한 없음: `FORBIDDEN`, `ACCESS_DENIED`
  - 리뷰/세션 없음: `BAD_REQUEST`, `ENTITY_NOT_FOUND`

#### 리뷰 내역 조회
- **API**: `GET /v1/mentee/review/list/{nickname}`
- **검증**: `ProfileService.isCurrentUser`로 조회 권한 확인
- **구현**: 
  - `findByMenteeIdWithMentorAndMentee` 쿼리로 N+1 문제 방지 
  - `findByMentoringSessionIdIn` 메소드로 해당 세션들의 리뷰 조회
  - `@Transactional(readOnly = true)`로 조회 성능 최적화
- **오류 처리**:
  - 조회 권한 없음: `FORBIDDEN`, `ACCESS_DENIED`
  - 사용자 없음: `NOT_FOUND`, `ENTITY_NOT_FOUND`

### 사용자 프로필 관련 로직 개선
- `isCurrentUser` 메소드를 `public static`으로 변경
- 사용자 ID뿐만 아니라 `provider`와 `providerId`도 함께 비교하도록 개선
- 모든 컨트롤러에서 `@AuthenticationPrincipal UserPrincipal`로 로그인 사용자 정보 조회

## ✅ 체크리스트 검증
- [x] 코드 점검 완료
- [x] 테스트 통과
- [x] 문서/주석 최신화

## 📚 기타 검증
- 리뷰 수정 및 삭제 시 본인 여부 체크 로직 포함 (isCurrentUser)
- 리뷰 작성 전 세션 목록은 멘토링 종료된 건만 조회됨