### PR TITLE
[ci] GitHub Actions에서 Supabase 라이브러리 인증 오류 해결 및 GPR 접근 권한 설정

### DIFF
--- a/.github/workflows/deploy-to-oci.yml
+++ b/.github/workflows/deploy-to-oci.yml
@@ -12,6 +12,11 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
 
+    # 🔽 GitHub Packages‧소스 읽기 권한 선언
+    permissions:
+      packages: read     # GitHub Packages(PKG) 다운로드
+      contents: read     # 리포지토리 checkout
+
     steps:
       # 소스코드 체크아웃
       - name: Checkout code

--- a/build.gradle
+++ b/build.gradle
@@ -26,12 +26,11 @@ configurations {
 repositories {
     mavenCentral()
     maven { url "https://jitpack.io" }
-
     maven {
         url = uri("https://maven.pkg.github.com/supabase-community/storage-java")
         credentials {
-            username = System.getenv("GITHUB_ACTOR") ?: "x-access-token"
-            password = System.getenv("GITHUB_TOKEN") ?: System.getenv("GITHUB_PACKAGES_TOKEN")
+            username = System.getenv("GITHUB_ACTOR")
+            password = System.getenv("GITHUB_TOKEN")
         }
     }
 }


### PR DESCRIPTION
## ✨ PR 종류

- [x] CI/CD 수정
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 🛠️ 작업 요약

- GitHub Actions 빌드 실패 원인인 Supabase 라이브러리 인증(401) 문제 해결
- GitHub Packages 접근 권한(`permissions.packages: read`) 추가

## 📝 작업 상세

- CI workflow 파일 (`deploy-to-oci.yml`)에 `permissions` 블록 추가  
  ```yaml
  permissions:
    packages: read
    contents: read
  ```

* 더 이상 `gradle.properties` 내 GPR 사용자/토큰 정보 불필요
* GitHub Actions 빌드 환경에서만 자동 인증이 적용됨
  → 로컬 개발 시에는 환경변수 또는 개인 `~/.gradle/gradle.properties` 유지 필요

## ✅ 체크리스트

* [x] GitHub Actions 빌드 테스트 통과
* [x] 로컬 개발 환경에서도 정상 동작 확인
* [x] 민감한 정보 유출 없음 (PAT 등은 커밋하지 않음)

## 📚 기타

* 참고: [https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions)

