### PR TITLE
[feat] Community 파트 리팩토링 및 more-detail 기능 보강

### DIFF
--- a/src/main/java/com/team05/linkup/domain/community/api/CommentController.java
+++ b/src/main/java/com/team05/linkup/domain/community/api/CommentController.java
@@ -1,16 +1,27 @@
 package com.team05.linkup.domain.community.api;
 
 import com.team05.linkup.common.dto.ApiResponse;
-import com.team05.linkup.domain.community.dto.CommentDto;
+import com.team05.linkup.common.dto.UserPrincipal;
+import com.team05.linkup.common.enums.ResponseCode;
 import com.team05.linkup.domain.community.application.CommentService;
+import com.team05.linkup.domain.community.dto.CommentDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
+import jakarta.validation.Valid;
 
+/**
+ * 커뮤니티 게시글 댓글 관련 요청을 처리하는 컨트롤러.
+ * 댓글 생성, 조회, 수정, 삭제 기능을 제공합니다.
+ */
 @RestController
 @RequestMapping("/v1/community")
 @RequiredArgsConstructor
@@ -19,39 +30,168 @@ public class CommentController {
 
     private final CommentService commentService;
 
+    /**
+     * 게시글의 댓글 목록을 페이징하여 조회합니다.
+     * 무한 스크롤 구현을 위한 Slice 타입을 반환합니다.
+     *
+     * @param communityId 댓글을 조회할 게시글 ID
+     * @param pageable 페이징 정보 (기본값: size=20, sort=createdAt)
+     * @return 댓글 목록과 다음 페이지 존재 여부
+     */
     @GetMapping("/{postId}/comments")
-    @Operation(summary = "댓글 목록 조회", description = "게시글의 댓글 목록을 조회합니다.")
-    public ApiResponse<List<CommentDto.Response>> getComments(
-            @PathVariable("postId") String communityId) {
-        return ApiResponse.success(commentService.getCommentsByCommunityId(communityId));
+    @Operation(summary = "댓글 목록 조회", description = "게시글의 댓글 목록을 조회합니다. 페이징을 지원하여 무한 스크롤 구현에 적합합니다.")
+    public ResponseEntity<ApiResponse<CommentDto.SliceResponse>> getComments(
+            @PathVariable("postId") String communityId,
+            @PageableDefault(size = 20, sort = "createdAt") Pageable pageable) {
+
+        try {
+            Slice<CommentDto.Response> comments = commentService.getCommentsSlice(communityId, pageable);
+            return ResponseEntity.ok(ApiResponse.success(
+                    new CommentDto.SliceResponse(comments.getContent(), comments.hasNext())
+            ));
+        } catch (jakarta.persistence.EntityNotFoundException e) {
+            return ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .body(ApiResponse.error(ResponseCode.ENTITY_NOT_FOUND));
+        }
     }
 
+    /**
+     * 특정 부모 댓글의 자식 댓글 목록을 페이징하여 조회합니다.
+     * 무한 스크롤 구현을 위한 Slice 타입을 반환합니다.
+     *
+     * @param parentId 자식 댓글을 조회할 부모 댓글 ID
+     * @param pageable 페이징 정보 (기본값: size=10, sort=createdAt)
+     * @return 자식 댓글 목록과 다음 페이지 존재 여부
+     */
+    @GetMapping("/comments/{parentId}/replies")
+    @Operation(summary = "답글 목록 조회", description = "부모 댓글에 대한 답글 목록을 조회합니다. 페이징을 지원하여 무한 스크롤 구현에 적합합니다.")
+    public ResponseEntity<ApiResponse<CommentDto.SliceResponse>> getChildComments(
+            @PathVariable("parentId") String parentId,
+            @PageableDefault(size = 10, sort = "createdAt") Pageable pageable) {
+
+        try {
+            Slice<CommentDto.Response> comments = commentService.getChildCommentsSlice(parentId, pageable);
+            return ResponseEntity.ok(ApiResponse.success(
+                    new CommentDto.SliceResponse(comments.getContent(), comments.hasNext())
+            ));
+        } catch (jakarta.persistence.EntityNotFoundException e) {
+            return ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .body(ApiResponse.error(ResponseCode.ENTITY_NOT_FOUND));
+        }
+    }
+
+    /**
+     * 게시글에 새 댓글을 작성합니다.
+     *
+     * @param principal 인증된 사용자 정보
+     * @param communityId 댓글을 작성할 게시글 ID
+     * @param request 댓글 내용을 포함한 요청 데이터
+     * @return 생성된 댓글 정보
+     */
     @PostMapping("/{postId}/comments")
     @Operation(summary = "댓글 작성", description = "게시글에 댓글을 작성합니다.")
-    public ApiResponse<CommentDto.Response> createComment(
-            @AuthenticationPrincipal String userId,
+    public ResponseEntity<ApiResponse<CommentDto.Response>> createComment(
+            @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable("postId") String communityId,
-            @RequestBody CommentDto.Request request) {
-        return ApiResponse.created(commentService.createComment(userId, communityId, request));
+            @Valid @RequestBody CommentDto.Request request) {
+
+        // 인증 처리 표준화
+        if (principal == null) {
+            return ResponseEntity
+                    .status(HttpStatus.UNAUTHORIZED)
+                    .body(ApiResponse.error(ResponseCode.UNAUTHORIZED));
+        }
+
+        try {
+            // providerId로 변경하여 일관성 유지
+            CommentDto.Response response = commentService.createComment(principal.providerId(), communityId, request);
+            return ResponseEntity
+                    .status(HttpStatus.CREATED)
+                    .body(ApiResponse.created(response));
+        } catch (jakarta.persistence.EntityNotFoundException e) {
+            return ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .body(ApiResponse.error(ResponseCode.ENTITY_NOT_FOUND));
+        }
     }
 
+    /**
+     * 기존 댓글을 수정합니다.
+     * 자신이 작성한 댓글만 수정할 수 있습니다.
+     *
+     * @param principal 인증된 사용자 정보
+     * @param communityId 댓글이 속한 게시글 ID
+     * @param commentId 수정할 댓글 ID
+     * @param request 수정할 댓글 내용
+     * @return 수정된 댓글 정보
+     */
     @PatchMapping("/comments/{postId}/{commentId}")
     @Operation(summary = "댓글 수정", description = "댓글을 수정합니다.")
-    public ApiResponse<CommentDto.Response> updateComment(
-            @AuthenticationPrincipal String userId,
+    public ResponseEntity<ApiResponse<CommentDto.Response>> updateComment(
+            @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable("postId") String communityId,
             @PathVariable("commentId") String commentId,
-            @RequestBody CommentDto.Request request) {
-        return ApiResponse.success(commentService.updateComment(userId, communityId, commentId, request));
+            @Valid @RequestBody CommentDto.Request request) {
+
+        // 인증 처리 표준화
+        if (principal == null) {
+            return ResponseEntity
+                    .status(HttpStatus.UNAUTHORIZED)
+                    .body(ApiResponse.error(ResponseCode.UNAUTHORIZED));
+        }
+
+        try {
+            // providerId로 변경하여 일관성 유지
+            CommentDto.Response response = commentService.updateComment(principal.providerId(), communityId, commentId, request);
+            return ResponseEntity.ok(ApiResponse.success(response));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity
+                    .status(HttpStatus.FORBIDDEN)
+                    .body(ApiResponse.error(ResponseCode.NO_EDIT_PERMISSION));
+        } catch (jakarta.persistence.EntityNotFoundException e) {
+            return ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .body(ApiResponse.error(ResponseCode.COMMENT_NOT_FOUND));
+        }
     }
 
+    /**
+     * 댓글을 삭제합니다.
+     * 자신이 작성한 댓글만 삭제할 수 있습니다.
+     *
+     * @param principal 인증된 사용자 정보
+     * @param communityId 댓글이 속한 게시글 ID
+     * @param commentId 삭제할 댓글 ID
+     * @return 성공 응답
+     */
     @DeleteMapping("/comments/{postId}/{commentId}")
     @Operation(summary = "댓글 삭제", description = "댓글을 삭제합니다.")
-    public ApiResponse<?> deleteComment(
-            @AuthenticationPrincipal String userId,
+    public ResponseEntity<ApiResponse<Void>> deleteComment(
+            @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable("postId") String communityId,
             @PathVariable("commentId") String commentId) {
-        commentService.deleteComment(userId, communityId, commentId);
-        return ApiResponse.success();
+
+        // 인증 처리 표준화
+        if (principal == null) {
+            return ResponseEntity
+                    .status(HttpStatus.UNAUTHORIZED)
+                    .body(ApiResponse.error(ResponseCode.UNAUTHORIZED));
+        }
+
+        try {
+            // providerId로 변경하여 일관성 유지
+            commentService.deleteComment(principal.providerId(), communityId, commentId);
+            return ResponseEntity.ok(ApiResponse.success());
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity
+                    .status(HttpStatus.FORBIDDEN)
+                    .body(ApiResponse.error(ResponseCode.NO_DELETE_PERMISSION));
+        } catch (jakarta.persistence.EntityNotFoundException e) {
+            return ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .body(ApiResponse.error(ResponseCode.COMMENT_NOT_FOUND));
+        }
     }
 }

--- a/src/main/java/com/team05/linkup/domain/community/api/CommunityController.java
+++ b/src/main/java/com/team05/linkup/domain/community/api/CommunityController.java
@@ -2,19 +2,27 @@ package com.team05.linkup.domain.community.api;
 
 import com.team05.linkup.common.dto.ApiResponse;
 import com.team05.linkup.common.dto.UserPrincipal;
+import com.team05.linkup.common.enums.ResponseCode;
 import com.team05.linkup.domain.community.application.CommunityImageService;
 import com.team05.linkup.domain.community.application.CommunityService;
 import com.team05.linkup.domain.community.domain.CommunityCategory;
 import com.team05.linkup.domain.community.dto.CommunityDto;
 import com.team05.linkup.domain.community.dto.CommunitySummaryResponse;
+import com.team05.linkup.domain.community.dto.ImageDto;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -35,7 +43,7 @@ public class CommunityController {
     private final CommunityService communityService;
     private final CommunityImageService communityImageService;
 
-    // private final CommentService commentService; // 댓글 관련 기능 필요 시 주입
+    /* -------------------------------------------------- 게시글 목록 조회 -------------------------------------------------- */
 
     /**
      * 카테고리별로 필터링된(선택) 커뮤니티 게시물의 페이지별 목록을 검색합니다.
@@ -81,7 +89,7 @@ public class CommunityController {
      * @param keyword 검색할 키워드 (필수).
      * @param pageable 페이징 및 정렬 정보 (선택 사항, 기본값 적용됨).
      * @return ResponseEntity containing an ApiResponse with a Page of CommunitySummaryResponse DTOs.
-     * Example URL: GET /v1/community/more-detail?keyword=spring
+     * Example URL: GET /v1/community/search?keyword=spring
      */
     @GetMapping("/search")
     @Operation(summary = "게시글 검색", description = "키워드로 게시글을 검색합니다.")
@@ -93,58 +101,257 @@ public class CommunityController {
         return ResponseEntity.ok(ApiResponse.success(searchResultPage));
     }
 
-    @PostMapping("/new")
-    @Operation(summary = "게시글 작성", description = "새로운 게시글을 작성합니다.")
-    public ApiResponse<CommunityDto.Response> createCommunity(
-            @AuthenticationPrincipal UserPrincipal userPrincipal,
-            @RequestBody CommunityDto.Request request) {
-        return ApiResponse.created(communityService.createCommunity(userPrincipal, request));
-    }
+    /* -------------------------------------------------- 게시글 상세 조회 -------------------------------------------------- */
 
+    /**
+     * ID로 게시글을 상세 조회합니다.
+     *
+     * @param principal 인증된 사용자 정보
+     * @param communityId 조회할 게시글 ID
+     * @return 게시글 상세 정보가 포함된 ApiResponse
+     */
     @GetMapping("/detail/{postId}")
     @Operation(summary = "게시글 상세 조회", description = "ID로 게시글을 상세 조회합니다.")
-    public ApiResponse<CommunityDto.DetailResponse> getCommunityDetail(
-            @AuthenticationPrincipal String userId,
+    public ResponseEntity<ApiResponse<CommunityDto.DetailResponse>> getCommunityDetail(
+            @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable("postId") String communityId) {
-        return ApiResponse.success(communityService.getCommunityDetail(userId, communityId));
+
+        // 인증되지 않은 사용자도 조회 가능하도록 처리 (있을 경우 회원 ID 사용, 없을 경우 null 전달)
+        String userId = principal != null ? principal.providerId() : null;
+        try {
+            return ResponseEntity.ok(ApiResponse.success(communityService.getCommunityDetail(userId, communityId)));
+        } catch (jakarta.persistence.EntityNotFoundException e) {
+            return ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .body(ApiResponse.error(ResponseCode.ENTITY_NOT_FOUND));
+        }
     }
 
-    @PostMapping("/more-detail")
-    @Operation(summary = "게시글 상세 조회(검색)", description = "검색 조건으로 게시글을 상세 조회합니다.")
-    public ApiResponse<CommunityDto.DetailResponse> searchCommunityDetail(
-            @RequestBody CommunityDto.SearchDetailRequest request) {
-        return ApiResponse.success(communityService.searchCommunityDetail(request));
+    /* -------------------------------------------------- 게시글 CRUD -------------------------------------------------- */
+
+    /**
+     * 새로운 게시글을 작성합니다.
+     *
+     * @param principal 인증된 사용자 정보
+     * @param request 게시글 작성 요청 데이터
+     * @return 생성된 게시글 정보
+     */
+    @Operation(
+            summary = "게시글 작성",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = CommunityDto.Request.class),
+                            examples = @ExampleObject(name = "요청 예시", value = """
+                                  {
+                                    "title": "스프링 질문 있습니다!",
+                                    "category": "QUESTION",
+                                    "communityTag": "SPRING",
+                                    "content": "Bean과 Component 차이가 뭔가요?"
+                                  }""")
+                    )
+            )
+    )
+    @PostMapping("/new")
+    public ResponseEntity<ApiResponse<CommunityDto.Response>> createPost(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody CommunityDto.Request request) {
+
+        // 인증 처리 표준화
+        if (principal == null) {
+            return ResponseEntity
+                    .status(HttpStatus.UNAUTHORIZED)
+                    .body(ApiResponse.error(ResponseCode.UNAUTHORIZED));
+        }
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.created(communityService.createCommunity(principal, request)));
     }
 
+    /**
+     * 기존 게시글을 수정합니다.
+     *
+     * @param principal 인증된 사용자 정보
+     * @param postId 수정할 게시글 ID
+     * @param request 게시글 수정 요청 데이터
+     * @return 수정된 게시글 정보
+     */
     @PatchMapping("/detail/{postId}")
     @Operation(summary = "게시글 수정", description = "기존 게시글을 수정합니다.")
-    public ApiResponse<CommunityDto.Response> updateCommunity(
-            @AuthenticationPrincipal String userId,
-            @PathVariable("postId") String communityId,
-            @RequestBody CommunityDto.Request request) {
-        return ApiResponse.success(communityService.updateCommunity(userId, communityId, request));
+    public ResponseEntity<ApiResponse<CommunityDto.Response>> updatePost(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable String postId,
+            @Valid @RequestBody CommunityDto.Request request) {
+
+        // 인증 처리 표준화
+        if (principal == null) {
+            return ResponseEntity
+                    .status(HttpStatus.UNAUTHORIZED)
+                    .body(ApiResponse.error(ResponseCode.UNAUTHORIZED));
+        }
+
+        try {
+            return ResponseEntity
+                    .ok(ApiResponse.success(communityService.updateCommunity(principal.providerId(), postId, request)));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity
+                    .status(HttpStatus.FORBIDDEN)
+                    .body(ApiResponse.error(ResponseCode.NO_EDIT_PERMISSION));
+        } catch (jakarta.persistence.EntityNotFoundException e) {
+            return ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .body(ApiResponse.error(ResponseCode.ENTITY_NOT_FOUND));
+        }
     }
 
+    /**
+     * 게시글을 삭제합니다.
+     *
+     * @param principal 인증된 사용자 정보
+     * @param postId 삭제할 게시글 ID
+     * @return 성공 응답
+     */
     @DeleteMapping("/{postId}")
     @Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다.")
-    public ApiResponse<?> deleteCommunity(
-            @AuthenticationPrincipal String userId,
-            @PathVariable("postId") String communityId) {
-        communityService.deleteCommunity(userId, communityId);
-        return ApiResponse.success();
+    public ResponseEntity<ApiResponse<Void>> deletePost(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable String postId) {
+
+        // 인증 처리 표준화
+        if (principal == null) {
+            return ResponseEntity
+                    .status(HttpStatus.UNAUTHORIZED)
+                    .body(ApiResponse.error(ResponseCode.UNAUTHORIZED));
+        }
+
+        try {
+            communityService.deleteCommunity(principal.providerId(), postId);
+            return ResponseEntity.ok(ApiResponse.success());
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity
+                    .status(HttpStatus.FORBIDDEN)
+                    .body(ApiResponse.error(ResponseCode.NO_DELETE_PERMISSION));
+        } catch (jakarta.persistence.EntityNotFoundException e) {
+            return ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .body(ApiResponse.error(ResponseCode.ENTITY_NOT_FOUND));
+        }
     }
 
-    @PostMapping("/{postId}/images")
-    @ResponseStatus(HttpStatus.CREATED)
-    public ApiResponse<List<String>> uploadImages(
+    /* -------------------------------------------------- 이미지 업로드 -------------------------------------------------- */
+
+    /**
+     * 게시글 이미지를 업로드합니다.
+     *
+     * @param postId 이미지를 첨부할 게시글 ID
+     * @param images 업로드할 이미지 파일 목록
+     * @param principal 인증된 사용자 정보
+     * @return 업로드된 이미지 경로 목록
+     */
+    @Operation(
+            summary = "게시글 이미지 업로드",
+            description = "Multipart 형식으로 이미지를 업로드하여 Supabase Storage 에 저장합니다.",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true,
+                    content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE))
+    )
+    @PostMapping(
+            value = "/{postId}/images",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<List<String>>> uploadImages(
             @PathVariable String postId,
-            @RequestPart List<MultipartFile> images,
-            @AuthenticationPrincipal String userId) {
+            @Parameter(description = "업로드할 이미지 파일들", required = true)
+            @RequestPart("images") List<MultipartFile> images,
+            @AuthenticationPrincipal UserPrincipal principal) {
 
-        List<String> objectPaths = communityImageService.uploadImages(userId, images);
-        communityService.attachImages(postId, objectPaths);
+        // 인증 처리 표준화
+        if (principal == null) {
+            return ResponseEntity
+                    .status(HttpStatus.UNAUTHORIZED)
+                    .body(ApiResponse.error(ResponseCode.UNAUTHORIZED));
+        }
 
-        return ApiResponse.success(objectPaths);
+        try {
+            // 수정: id() → providerId() 로 변경
+            List<String> objectPaths = communityImageService.uploadImages(principal.providerId(), images);
+            // 수정: 매개변수 3개 → 2개로 변경
+            communityService.attachImages(postId, objectPaths);
+
+            return ResponseEntity
+                    .status(HttpStatus.CREATED)
+                    // 수정: ImageDto.Response.of() 메서드 제거하고 직접 리스트 반환
+                    .body(ApiResponse.created(objectPaths));
+        } catch (jakarta.persistence.EntityNotFoundException e) {
+            return ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .body(ApiResponse.error(ResponseCode.ENTITY_NOT_FOUND));
+        } catch (Exception e) {
+            return ResponseEntity
+                    .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.error(ResponseCode.INTERNAL_SERVER_ERROR, "이미지 업로드 실패: " + e.getMessage()));
+        }
     }
 
+    /* -------------------------------------------------- 통합 검색(more - detail) -------------------------------------------- */
+
+    /**
+     * 게시글 상세 조회(검색) 엔드포인트.
+     * ID가 제공된 경우 특정 게시글의 상세 정보를 조회하고,
+     * 그 외의 경우 다양한 조건으로 게시글을 검색합니다.
+     *
+     * @param request 검색 조건 (ID 또는 다양한 검색 조건)
+     * @param pageable 페이징 정보 (고급 검색 시에만 사용)
+     * @return 검색 결과 (단일 게시글 또는 게시글 목록)
+     */
+    @PostMapping("/more-detail")
+    @Operation(
+            summary = "게시글 상세 조회 또는 고급 검색",
+            description = "ID로 특정 게시글을 상세 조회하거나 다양한 조건(키워드, 닉네임, 카테고리, 역할, 태그)으로 게시글을 검색합니다.",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = CommunityDto.SearchDetailRequest.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "ID로 조회",
+                                            value = """
+                        {
+                          "id": "123e4567-e89b-12d3-a456-426614174000"
+                        }
+                        """
+                                    ),
+                                    @ExampleObject(
+                                            name = "고급 검색",
+                                            value = """
+                        {
+                          "keyword": "스프링",
+                          "nickname": "멘토1",
+                          "category": "QUESTION",
+                          "userRole": "ROLE_MENTOR",
+                          "tag": "SPRING"
+                        }
+                        """
+                                    )
+                            }
+                    )
+            )
+    )
+    public ResponseEntity<ApiResponse<?>> searchCommunityDetail(
+            @Valid @RequestBody CommunityDto.SearchDetailRequest request,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        Object result = communityService.searchCommunityDetail(request, pageable);
+
+        // 결과 타입에 따라 응답 생성
+        if (result instanceof CommunityDto.DetailResponse) {
+            return ResponseEntity.ok(ApiResponse.success(result));
+        } else if (result instanceof Page) {
+            return ResponseEntity.ok(ApiResponse.success(result));
+        } else {
+            return ResponseEntity
+                    .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.error(ResponseCode.INTERNAL_SERVER_ERROR, "예상치 못한 응답 형식"));
+        }
+    }
 }

--- a/src/main/java/com/team05/linkup/domain/community/application/CommentService.java
+++ b/src/main/java/com/team05/linkup/domain/community/application/CommentService.java
@@ -1,12 +1,18 @@
 package com.team05.linkup.domain.community.application;
 
 import com.team05.linkup.domain.community.domain.Comment;
+import com.team05.linkup.domain.community.domain.Community;
 import com.team05.linkup.domain.community.dto.CommentDto;
 import com.team05.linkup.domain.community.infrastructure.CommentRepository;
+import com.team05.linkup.domain.community.infrastructure.CommunityRepository;
 import com.team05.linkup.domain.user.domain.User;
 import com.team05.linkup.domain.user.infrastructure.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,14 +20,26 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+/**
+ * 댓글 관련 비즈니스 로직을 처리하는 서비스 클래스입니다.
+ * 댓글 조회, 생성, 수정, 삭제 기능을 제공합니다.
+ */
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class CommentService {
 
     private final CommentRepository commentRepository;
+    private final CommunityRepository communityRepository;
     private final UserRepository userRepository;
 
+    /**
+     * 게시글 ID로 모든 댓글을 조회합니다. (페이징 없음)
+     * 부모 댓글과 각 부모 댓글의 자식 댓글을 함께 조회합니다.
+     *
+     * @param communityId 게시글 ID
+     * @return 댓글 목록 (부모 댓글과 자식 댓글 포함)
+     */
     public List<CommentDto.Response> getCommentsByCommunityId(String communityId) {
         // 부모 댓글만 조회 (parentCommentId가 null인 것)
         List<Comment> parentComments = commentRepository.findParentCommentsByCommunityId(communityId);
@@ -35,6 +53,104 @@ public class CommentService {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * 게시글 ID로 댓글을 페이징하여 조회합니다. (무한 스크롤용)
+     * 부모 댓글과 각 부모 댓글의 자식 댓글을 함께 조회합니다.
+     *
+     * @param communityId 게시글 ID
+     * @param pageable 페이징 정보
+     * @return 댓글 목록의 슬라이스 (다음 페이지 존재 여부 포함)
+     * @throws EntityNotFoundException 게시글이 존재하지 않는 경우
+     */
+    public Slice<CommentDto.Response> getCommentsSlice(String communityId, Pageable pageable) {
+        // 페이지 요청 시, 1개 더 많은 항목을 요청하여 다음 페이지 존재 여부 확인
+        Pageable pageWithExtra = PageRequest.of(
+                pageable.getPageNumber(),
+                pageable.getPageSize() + 1,
+                pageable.getSort()
+        );
+
+        // 게시글 존재 여부 확인
+        if (!communityRepository.existsById(communityId)) {
+            throw new EntityNotFoundException("게시글을 찾을 수 없습니다.");
+        }
+
+        // 부모 댓글만 페이징 조회
+        List<Comment> parentComments = commentRepository.findParentCommentsByCommunityIdWithPaging(
+                communityId,
+                pageWithExtra
+        );
+
+        // 다음 페이지 존재 여부 확인
+        boolean hasNext = false;
+        if (parentComments.size() > pageable.getPageSize()) {
+            parentComments.remove(parentComments.size() - 1);
+            hasNext = true;
+        }
+
+        // 각 부모 댓글에 대한 자식 댓글 조회 (N+1 문제 주의)
+        List<CommentDto.Response> responseList = parentComments.stream()
+                .map(parent -> {
+                    List<Comment> childComments = commentRepository.findChildCommentsByParentId(parent.getId());
+                    return CommentDto.Response.from(parent, childComments);
+                })
+                .collect(Collectors.toList());
+
+        return new SliceImpl<>(responseList, pageable, hasNext);
+    }
+
+    /**
+     * 특정 부모 댓글의 자식 댓글을 페이징하여 조회합니다.
+     * 무한 스크롤 구현을 위한 메서드입니다.
+     *
+     * @param parentId 부모 댓글 ID
+     * @param pageable 페이징 정보
+     * @return 댓글 목록의 슬라이스 (다음 페이지 존재 여부 포함)
+     * @throws EntityNotFoundException 부모 댓글이 존재하지 않는 경우
+     */
+    public Slice<CommentDto.Response> getChildCommentsSlice(String parentId, Pageable pageable) {
+        // 부모 댓글 존재 여부 확인
+        Comment parentComment = commentRepository.findById(parentId)
+                .orElseThrow(() -> new EntityNotFoundException("부모 댓글을 찾을 수 없습니다."));
+
+        // 페이지 요청 시, 1개 더 많은 항목을 요청하여 다음 페이지 존재 여부 확인
+        Pageable pageWithExtra = PageRequest.of(
+                pageable.getPageNumber(),
+                pageable.getPageSize() + 1,
+                pageable.getSort()
+        );
+
+        // 자식 댓글 페이징 조회
+        List<Comment> childComments = commentRepository.findChildCommentsByParentIdWithPaging(
+                parentId,
+                pageWithExtra
+        );
+
+        // 다음 페이지 존재 여부 확인
+        boolean hasNext = false;
+        if (childComments.size() > pageable.getPageSize()) {
+            childComments.remove(childComments.size() - 1);
+            hasNext = true;
+        }
+
+        // 응답 DTO 변환
+        List<CommentDto.Response> responseList = childComments.stream()
+                .map(child -> CommentDto.Response.from(child, List.of()))
+                .collect(Collectors.toList());
+
+        return new SliceImpl<>(responseList, pageable, hasNext);
+    }
+
+    /**
+     * 새로운 댓글을 생성합니다.
+     * 부모 댓글인 경우 순서 번호를 할당합니다.
+     *
+     * @param userId 사용자 ID
+     * @param communityId 게시글 ID
+     * @param request 댓글 생성 요청 데이터
+     * @return 생성된 댓글 정보
+     * @throws EntityNotFoundException 사용자가 존재하지 않는 경우
+     */
     @Transactional
     public CommentDto.Response createComment(String userId, String communityId, CommentDto.Request request) {
         User user = userRepository.findById(userId)
@@ -57,6 +173,13 @@ public class CommentService {
         return CommentDto.Response.from(savedComment, List.of());
     }
 
+    /**
+     * 다음 순서 번호를 계산합니다.
+     * 부모 댓글의 정렬 순서를 관리하는데 사용됩니다.
+     *
+     * @param communityId 게시글 ID
+     * @return 다음 순서 번호
+     */
     private Long getNextOrderNumber(String communityId) {
         List<Comment> existingComments = commentRepository.findByCommunityIdAndParentCommentIdIsNullOrderByOrderNumber(communityId);
         if (existingComments.isEmpty()) {
@@ -67,6 +190,18 @@ public class CommentService {
         }
     }
 
+    /**
+     * 기존 댓글을 수정합니다.
+     * 작성자만 수정할 수 있습니다.
+     *
+     * @param userId 사용자 ID
+     * @param communityId 게시글 ID
+     * @param commentId 수정할 댓글 ID
+     * @param request 댓글 수정 요청 데이터
+     * @return 수정된 댓글 정보
+     * @throws EntityNotFoundException 댓글이 존재하지 않는 경우
+     * @throws IllegalArgumentException 댓글 작성자가 아닌 경우
+     */
     @Transactional
     public CommentDto.Response updateComment(String userId, String communityId, String commentId, CommentDto.Request request) {
         Comment comment = commentRepository.findById(commentId)
@@ -87,6 +222,16 @@ public class CommentService {
         return CommentDto.Response.from(comment, childComments);
     }
 
+    /**
+     * 댓글을 삭제합니다.
+     * 작성자만 삭제할 수 있으며, 부모 댓글 삭제 시 자식 댓글도 함께 삭제됩니다.
+     *
+     * @param userId 사용자 ID
+     * @param communityId 게시글 ID
+     * @param commentId 삭제할 댓글 ID
+     * @throws EntityNotFoundException 댓글이 존재하지 않는 경우
+     * @throws IllegalArgumentException 댓글 작성자가 아닌 경우
+     */
     @Transactional
     public void deleteComment(String userId, String communityId, String commentId) {
         Comment comment = commentRepository.findById(commentId)

--- a/src/main/java/com/team05/linkup/domain/community/dto/CommentDto.java
+++ b/src/main/java/com/team05/linkup/domain/community/dto/CommentDto.java
@@ -1,8 +1,6 @@
 package com.team05.linkup.domain.community.dto;
 
 import com.team05.linkup.domain.community.domain.Comment;
-import com.team05.linkup.domain.user.domain.User;
-import com.team05.linkup.domain.user.infrastructure.UserRepository;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,8 +9,16 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * 댓글 기능과 관련된 DTO 클래스들을 정의합니다.
+ * 댓글 작성 요청, 응답, 무한 스크롤을 위한 페이징 응답 등을 포함합니다.
+ */
 public class CommentDto {
 
+    /**
+     * 댓글 작성 및 수정 요청 DTO
+     * 댓글 내용과 부모 댓글 ID(답글인 경우)를 포함합니다.
+     */
     @Getter
     @NoArgsConstructor
     public static class Request {
@@ -20,28 +26,37 @@ public class CommentDto {
         private String parentCommentId; // 답글인 경우에만 사용
     }
 
+    /**
+     * 댓글 응답 DTO
+     * 댓글의 상세 정보와 하위 댓글 목록을 포함합니다.
+     */
     @Getter
     @Builder
     public static class Response {
-        private String id;
-        private String userId;
-        private String nickname;
-        private String profileImageUrl;
-        private String commentContent;
-        private boolean isParent;
-        private int totalLikeCount;
-        private ZonedDateTime createdAt;
-        private ZonedDateTime updatedAt;
-        private List<Response> childComments;
+        private String id;                  // 댓글 ID
+        private String userId;              // 작성자 ID
+        private String nickname;            // 작성자 닉네임
+        private String profileImageUrl;     // 작성자 프로필 이미지 URL
+        private String commentContent;      // 댓글 내용
+        private boolean isParent;           // 부모 댓글 여부
+        private int totalLikeCount;         // 좋아요 수
+        private ZonedDateTime createdAt;    // 생성 시간
+        private ZonedDateTime updatedAt;    // 수정 시간
+        private List<Response> childComments; // 하위 댓글 목록
 
+        /**
+         * Comment 엔티티와 하위 댓글 목록으로부터 Response DTO를 생성합니다.
+         *
+         * @param comment 댓글 엔티티
+         * @param childComments 하위 댓글 목록
+         * @return 댓글 응답 DTO
+         */
         public static Response from(Comment comment, List<Comment> childComments) {
-            User user = null; // 실제 구현에서는 userRepository를 통해 조회
-
             return Response.builder()
                     .id(comment.getId())
                     .userId(comment.getUserId())
                     .nickname(comment.getName()) // User 객체 대신 name 필드 사용
-                    .profileImageUrl(user != null ? user.getProfileImageUrl() : null)
+                    .profileImageUrl(null) // 필요시 User 조회하여 채움
                     .commentContent(comment.getCommentContent())
                     .isParent(comment.getParentCommentId() == null) // parentCommentId 기준으로 판단
                     .totalLikeCount(comment.getTotalLikeCount())
@@ -51,6 +66,28 @@ public class CommentDto {
                             .map(child -> Response.from(child, List.of()))
                             .collect(Collectors.toList()))
                     .build();
+        }
+    }
+
+    /**
+     * 무한 스크롤을 위한 Slice 응답 DTO
+     * 현재 페이지의 댓글 목록과 다음 페이지 존재 여부를 포함합니다.
+     */
+    @Getter
+    @Builder
+    public static class SliceResponse {
+        private final List<Response> content;  // 댓글 목록
+        private final boolean hasNext;         // 다음 페이지 존재 여부
+
+        /**
+         * 댓글 목록과 다음 페이지 존재 여부로 SliceResponse를 생성합니다.
+         *
+         * @param content 댓글 목록
+         * @param hasNext 다음 페이지 존재 여부
+         */
+        public SliceResponse(List<Response> content, boolean hasNext) {
+            this.content = content;
+            this.hasNext = hasNext;
         }
     }
 }

--- a/src/main/java/com/team05/linkup/domain/community/dto/CommunityDto.java
+++ b/src/main/java/com/team05/linkup/domain/community/dto/CommunityDto.java
@@ -9,25 +9,53 @@ import lombok.NoArgsConstructor;
 import java.time.ZonedDateTime;
 import java.util.List;
 
+/**
+ * 커뮤니티 기능과 관련된 DTO 클래스들을 정의합니다.
+ * 게시글 생성/수정, 상세조회, 검색 등에 사용되는 데이터 구조를 포함합니다.
+ */
 public class CommunityDto {
 
+    /**
+     * 커뮤니티 게시글 생성 및 수정 요청 DTO
+     */
     @Getter
     @NoArgsConstructor
     public static class Request {
+        @NotBlank(message = "제목은 필수 입력값입니다.")
         private String title;
+
+        @NotBlank(message = "카테고리는 필수 입력값입니다.")
         private String category;
+
         private String communityTag;
+
+        @NotBlank(message = "내용은 필수 입력값입니다.")
         private String content;
     }
 
+    /**
+     * 커뮤니티 게시글 검색 요청 DTO
+     * ID, 키워드, 닉네임 등 다양한 조건으로 게시글을 검색할 수 있습니다.
+     */
     @Getter
     @NoArgsConstructor
     public static class SearchDetailRequest {
-        private String id;  // 검색 시 사용되는 ID
-        private String keyword;
-        private String nickname;
+        private String id;         // 검색 시 사용되는 ID
+        private String keyword;    // 검색 키워드 (제목, 내용 등)
+        private String nickname;   // 작성자 닉네임
+
+        // 확장된 검색 필드
+        private String category;   // 카테고리 검색
+        private String userRole;   // 작성자 역할 검색 (ROLE_MENTOR/ROLE_MENTEE)
+        private String tag;        // 태그 검색
+        private String sortBy;     // 정렬 기준 (createdAt, viewCount, likeCount)
+        private String direction;  // 정렬 방향 (asc, desc)
     }
 
+    /**
+     * 커뮤니티 게시글 기본 응답 DTO
+     * 목록 조회 등에서 사용되는 간략한 정보를 포함합니다.
+     */
     @Getter
     @Builder
     public static class Response {
@@ -40,6 +68,12 @@ public class CommunityDto {
         private ZonedDateTime createdAt;
         private ZonedDateTime updatedAt;
 
+        /**
+         * Community 엔티티로부터 Response DTO를 생성합니다.
+         *
+         * @param community 게시글 엔티티
+         * @return 게시글 응답 DTO
+         */
         public static Response from(Community community) {
             return Response.builder()
                     .id(community.getId())
@@ -54,6 +88,10 @@ public class CommunityDto {
         }
     }
 
+    /**
+     * 커뮤니티 게시글 상세 응답 DTO
+     * 게시글의 모든 상세 정보를 포함합니다.
+     */
     @Getter
     @Builder
     public static class DetailResponse {
@@ -65,13 +103,50 @@ public class CommunityDto {
         private String category;
         private String communityTag;
         private String content;
-        private int viewCount; // Long에서 int로 변환
-        private int likeCount; // Long에서 int로 변환
+        private int viewCount;     // Long에서 int로 변환
+        private int likeCount;     // Long에서 int로 변환
         private int commentCount;
         private boolean isLiked;
         private boolean isBookmarked;
         private List<String> imageUrls;
         private ZonedDateTime createdAt;
         private ZonedDateTime updatedAt;
+    }
+
+    /**
+     * 커뮤니티 게시글 목록 요약 응답 DTO
+     * 목록 조회 시 필요한 간략한 정보만 포함합니다.
+     */
+    @Getter
+    @Builder
+    public static class CommunitySummaryResponse {
+        private String id;
+        private String userId;
+        private String nickname;
+        private String profileImageUrl;
+        private String title;
+        private String category;
+        private String communityTag;
+        private String content;
+        private int viewCount;
+        private int likeCount;
+        private int commentCount;
+        private ZonedDateTime createdAt;
+
+        /**
+         * 미리보기용 내용 생성 (최대 100자)
+         */
+        public String getPreviewContent() {
+            if (content == null) {
+                return "";
+            }
+
+            int maxLength = 100;
+            if (content.length() <= maxLength) {
+                return content;
+            }
+
+            return content.substring(0, maxLength) + "...";
+        }
     }
 }

--- a/src/main/java/com/team05/linkup/domain/community/dto/ImageDto.java
+++ b/src/main/java/com/team05/linkup/domain/community/dto/ImageDto.java
@@ -5,10 +5,31 @@ import lombok.Getter;
 
 import java.util.List;
 
+/**
+ * 이미지 관련 데이터 전송 객체를 정의하는 클래스입니다.
+ * 이미지 URL 목록을 주고받기 위한 DTO 구조를 포함합니다.
+ */
 public class ImageDto {
+
+    /**
+     * 이미지 응답 DTO
+     * 업로드된 이미지 URL 목록을 포함합니다.
+     */
     @Getter
     @Builder
     public static class Response {
-        private List<String> imageUrls;
+        private final List<String> imageUrls;
+
+        /**
+         * URL 목록으로부터 Response 객체를 생성하는 팩토리 메서드
+         *
+         * @param urls 이미지 URL 목록
+         * @return 생성된 Response 객체
+         */
+        public static Response of(List<String> urls) {
+            return Response.builder()
+                    .imageUrls(urls)
+                    .build();
+        }
     }
 }

--- a/src/main/java/com/team05/linkup/domain/community/infrastructure/CommentRepository.java
+++ b/src/main/java/com/team05/linkup/domain/community/infrastructure/CommentRepository.java
@@ -1,24 +1,88 @@
 package com.team05.linkup.domain.community.infrastructure;
 
 import com.team05.linkup.domain.community.domain.Comment;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
+/**
+ * 댓글 엔티티에 대한 데이터 액세스 인터페이스입니다.
+ * Spring Data JPA를 활용하여 댓글 데이터를 조회, 저장, 수정, 삭제하는 기능을 제공합니다.
+ */
 public interface CommentRepository extends JpaRepository<Comment, String> {
 
+    /**
+     * 특정 게시글의 모든 부모 댓글을 조회합니다.
+     * 부모 댓글은 parentCommentId가 null인 댓글입니다.
+     * 결과는 orderNumber 기준으로 정렬됩니다.
+     *
+     * @param communityId 게시글 ID
+     * @return 부모 댓글 목록
+     */
     @Query("SELECT c FROM Comment c WHERE c.communityId = :communityId AND c.parentCommentId IS NULL ORDER BY c.orderNumber")
     List<Comment> findParentCommentsByCommunityId(@Param("communityId") String communityId);
 
+    /**
+     * 특정 게시글의 부모 댓글을 페이징하여 조회합니다.
+     * 무한 스크롤 구현을 위한 메서드입니다.
+     * 결과는 orderNumber 기준으로 정렬됩니다.
+     *
+     * @param communityId 게시글 ID
+     * @param pageable 페이징 정보
+     * @return 페이징된 부모 댓글 목록
+     */
+    @Query("SELECT c FROM Comment c WHERE c.communityId = :communityId AND c.parentCommentId IS NULL ORDER BY c.orderNumber")
+    List<Comment> findParentCommentsByCommunityIdWithPaging(@Param("communityId") String communityId, Pageable pageable);
+
+    /**
+     * 특정 부모 댓글의 모든 자식 댓글을 조회합니다.
+     * 자식 댓글은 parentCommentId가 지정된 댓글입니다.
+     * 결과는 createdAt 기준으로 정렬됩니다.
+     *
+     * @param parentId 부모 댓글 ID
+     * @return 자식 댓글 목록
+     */
     @Query("SELECT c FROM Comment c WHERE c.parentCommentId = :parentId ORDER BY c.createdAt")
     List<Comment> findChildCommentsByParentId(@Param("parentId") String parentId);
 
-    // Method name 쿼리 수정
+    /**
+     * 특정 부모 댓글의 자식 댓글을 페이징하여 조회합니다.
+     * 무한 스크롤 구현을 위한 메서드입니다.
+     * 결과는 createdAt 기준으로 정렬됩니다.
+     *
+     * @param parentId 부모 댓글 ID
+     * @param pageable 페이징 정보
+     * @return 페이징된 자식 댓글 목록
+     */
+    @Query("SELECT c FROM Comment c WHERE c.parentCommentId = :parentId ORDER BY c.createdAt")
+    List<Comment> findChildCommentsByParentIdWithPaging(@Param("parentId") String parentId, Pageable pageable);
+
+    /**
+     * 특정 게시글의 부모 댓글을 orderNumber 기준으로 정렬하여 조회합니다.
+     * 메서드 이름 쿼리를 사용합니다.
+     *
+     * @param communityId 게시글 ID
+     * @return 정렬된 부모 댓글 목록
+     */
     List<Comment> findByCommunityIdAndParentCommentIdIsNullOrderByOrderNumber(String communityId);
 
+    /**
+     * 특정 부모 댓글의 모든 자식 댓글을 생성 시간 기준으로 정렬하여 조회합니다.
+     * 메서드 이름 쿼리를 사용합니다.
+     *
+     * @param parentCommentId 부모 댓글 ID
+     * @return 정렬된 자식 댓글 목록
+     */
     List<Comment> findByParentCommentIdOrderByCreatedAt(String parentCommentId);
 
+    /**
+     * 특정 게시글의 총 댓글 수를 계산합니다.
+     *
+     * @param communityId 게시글 ID
+     * @return 댓글 수
+     */
     Integer countByCommunityId(String communityId);
 }

--- a/src/main/java/com/team05/linkup/domain/community/infrastructure/CommunityRepositoryCustom.java
+++ b/src/main/java/com/team05/linkup/domain/community/infrastructure/CommunityRepositoryCustom.java
@@ -1,5 +1,7 @@
 package com.team05.linkup.domain.community.infrastructure;
 
+import com.team05.linkup.domain.community.domain.Community;
+import com.team05.linkup.domain.community.domain.CommunityCategory;
 import com.team05.linkup.domain.user.dto.CommunityQnAPostDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -18,4 +20,24 @@ public interface CommunityRepositoryCustom {
     List<CommunityQnAPostDTO> findRecentQnAPostsByInterest(String interest, int limit);
 
     Page<CommunityQnAPostDTO> findRecentQnAPostsByInterestPaged(String interest, Pageable pageable);
+
+    /**
+     * 다양한 조건으로 게시글을 고급 검색합니다.
+     *
+     * @param keyword 검색 키워드 (제목, 내용, 태그에서 검색)
+     * @param nickname 작성자 닉네임
+     * @param category 게시글 카테고리
+     * @param userRole 사용자 역할 (ROLE_MENTOR, ROLE_MENTEE 등)
+     * @param tag 게시글 태그
+     * @param pageable 페이징 정보
+     * @return 검색 결과 페이지
+     */
+    Page<Community> advancedSearch(
+            String keyword,
+            String nickname,
+            CommunityCategory category,
+            String userRole,
+            String tag,
+            Pageable pageable
+    );
 }


### PR DESCRIPTION
# PR 제목: 커뮤니티 게시글 고급 검색 기능 구현

## ✨ PR 종류
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 🛠️ 작업 요약
- 커뮤니티 게시글 다중 조건 검색 기능 구현 및 기존 검색 API 확장

## 📝 작업 상세
- 작업 1: CommunityRepositoryCustom 인터페이스에 고급 검색 메서드 추가
- 작업 2: QueryDSL을 활용한 동적 쿼리 기반 검색 기능 구현
- 작업 3: 기존 '/more-detail' 엔드포인트에 고급 검색 기능 통합
- 작업 4: 키워드, 닉네임, 카테고리, 사용자 역할, 태그 등 다양한 검색 조건 지원
- 작업 5: 검색 결과 페이징 처리 구현

## ✅ 체크리스트
- [x] 코드 점검 완료
- [x] 테스트 통과
- [x] 문서/주석 최신화

## 📚 기타
- QueryDSL을 활용하여 동적 쿼리 생성 방식으로 구현했으며, 추후 정렬 옵션(sortBy, direction) 기능 확장이 필요함
- 기존 검색 기능과의 호환성을 유지하면서 새로운 기능 추가