### PR TITLE
[feat] 나의 활동 내역 조회 more-details (내가 신청한 매칭) 기능 추가 및 멘토 연락 링크 포함

### DIFF
--- a/src/main/java/com/team05/linkup/domain/mentoring/dto/MatchedMentorProfileDto.java
+++ b/src/main/java/com/team05/linkup/domain/mentoring/dto/MatchedMentorProfileDto.java
@@ -26,6 +26,6 @@ public class MatchedMentorProfileDto {
         private String interest;
         private String activityTime;
         private String activityType;
-
+        private String contactLink;
     }
 }

--- a/src/main/java/com/team05/linkup/domain/mentoring/infrastructure/MentoringRepository.java
+++ b/src/main/java/com/team05/linkup/domain/mentoring/infrastructure/MentoringRepository.java
@@ -2,6 +2,7 @@ package com.team05.linkup.domain.mentoring.infrastructure;
 
 import com.team05.linkup.domain.enums.MentoringStatus;
 import com.team05.linkup.domain.mentoring.domain.MentoringSessions;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -56,4 +57,11 @@ public interface MentoringRepository extends JpaRepository<MentoringSessions, St
     """, nativeQuery = true)
     List<Object[]> getMentorStatisticsFromView(@Param("mentorId") String mentorId);
 
+    // 닉네임으로 menteeId 조회
+    @Query("SELECT u.id FROM User u WHERE u.nickname = :nickname")
+    String findMenteeIdByNickname(@Param("nickname") String nickname);
+
+    // menteeId로 페이징된 매칭 세션 조회
+    @Query("SELECT m FROM MentoringSessions m WHERE m.mentee.id = :menteeId")
+    Page<MentoringSessions> findByMenteeUserIdPaged(@Param("menteeId") String menteeId, Pageable pageable);
 }

--- a/src/main/java/com/team05/linkup/domain/user/application/MenteeProfileService.java
+++ b/src/main/java/com/team05/linkup/domain/user/application/MenteeProfileService.java
@@ -33,7 +33,9 @@ public class MenteeProfileService {
                                 .interest(session.getMentor().getInterest().getDisplayName())
                                 .activityTime(session.getMentor().getActivityTime().getDisplayName())
                                 .activityType(session.getMentor().getActivityType().getDisplayName())
+                                .contactLink(session.getMentor().getContactLink())
                                 .build())
                         .build())
-                .toList();    }
+                .toList();
+    }
 }

--- a/src/main/java/com/team05/linkup/domain/user/application/MenteeProfileService.java
+++ b/src/main/java/com/team05/linkup/domain/user/application/MenteeProfileService.java
@@ -4,7 +4,11 @@ import com.team05.linkup.domain.mentoring.domain.MentoringSessions;
 import com.team05.linkup.domain.mentoring.dto.MatchedMentorProfileDto;
 import com.team05.linkup.domain.mentoring.infrastructure.MentoringRepository;
 
+import com.team05.linkup.domain.user.dto.MyCommentResponseDTO;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,17 +29,40 @@ public class MenteeProfileService {
                         .sessionId(session.getId())
                         .status(session.getStatus().name())
                         .createdAt(session.getCreatedAt())
-                        .mentor(MatchedMentorProfileDto.MentorDto.builder()
-                                .mentorId(session.getMentor().getId())
-                                .nickname(session.getMentor().getNickname())
-                                .profileImageUrl(session.getMentor().getProfileImageUrl())
-                                .introduction(session.getMentor().getIntroduction())
-                                .interest(session.getMentor().getInterest().getDisplayName())
-                                .activityTime(session.getMentor().getActivityTime().getDisplayName())
-                                .activityType(session.getMentor().getActivityType().getDisplayName())
-                                .contactLink(session.getMentor().getContactLink())
-                                .build())
+                        .mentor(mapToMentorDto(session))
                         .build())
                 .toList();
+    }
+
+    public Page<MatchedMentorProfileDto> getMyMatchesPaged(String nickname, int page, int size) {
+        // 1. 페이징 객체 생성
+        Pageable pageable = PageRequest.of(page, size);
+
+        // 2. 닉네임 기반으로 menteeId 조회
+        String menteeId = mentoringRepository.findMenteeIdByNickname(nickname);
+
+        // 3. 페이징된 매칭 세션 조회
+        Page<MentoringSessions> sessionsPage = mentoringRepository.findByMenteeUserIdPaged(menteeId, pageable);
+
+        // 4. DTO로 매핑
+        return sessionsPage.map(session -> MatchedMentorProfileDto.builder()
+                .sessionId(session.getId())
+                .status(session.getStatus().name())
+                .createdAt(session.getCreatedAt())
+                .mentor(mapToMentorDto(session))
+                .build());
+    }
+
+    private MatchedMentorProfileDto.MentorDto mapToMentorDto(MentoringSessions session) {
+        return MatchedMentorProfileDto.MentorDto.builder()
+                .mentorId(session.getMentor().getId())
+                .nickname(session.getMentor().getNickname())
+                .profileImageUrl(session.getMentor().getProfileImageUrl())
+                .introduction(session.getMentor().getIntroduction())
+                .interest(session.getMentor().getInterest().getDisplayName())
+                .activityTime(session.getMentor().getActivityTime().getDisplayName())
+                .activityType(session.getMentor().getActivityType().getDisplayName())
+                .contactLink(session.getMentor().getContactLink())
+                .build();
     }
 }


### PR DESCRIPTION
## ✨ PR 종류

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 🛠️ 작업 요약

-   **멘티 사용자가 신청한 매칭 목록을 페이징하여 조회**하는 기능 추가 (나의 활동 내역 more-details)
-   신청한 매칭 목록 조회 시, **멘토 정보에 `contactLink`를 포함**하도록 수정
-   페이징된 매칭 세션을 조회하기 위해 `MentoringRepository`에 새로운 쿼리 메소드(`findByMenteeUserIdPaged`) 추가
-   `ProfileController`에 "나의 활동 내역 more-details" 엔드포인트(`GET /v1/users/{nickname}/activity/more-details`)에서 `type=my-matches`를 처리하는 로직 추가
-   `MenteeProfileService`에서 페이징된 매칭 데이터를 조회하고 DTO로 변환하는 로직 구현
-   `MatchedMentorProfileDto.MentorDto`에 `contactLink` 필드 추가

## 📝 작업 상세

### 나의 활동 내역 - 신청한 매칭 상세 조회 기능 구현 (페이징 포함)

*   **API**: `GET /v1/users/{nickname}/activity/more-details?type=my-matches`
*   **기능**: 특정 멘티 사용자가 신청한 멘토링 세션 목록을 페이징하여 상세 조회합니다.
*   **구현**:
    *   `ProfileController`에 `getActivityMoreDetails` 메소드를 통해 요청을 처리하도록 추가되었습니다.
    *   `type` 파라미터가 `my-matches`일 경우, `MenteeProfileService`의 `getMyMatchesPaged` 메소드를 호출합니다.
    *   `MenteeProfileService`는 닉네임을 통해 멘티 ID를 조회하고, `MentoringRepository`의 `findByMenteeUserIdPaged` 메소드를 사용하여 페이징된 멘토링 세션을 조회합니다.
    *   조회된 멘토링 세션(`MentoringSessions`) 목록을 `MatchedMentorProfileDto` 형식으로 변환하여 반환합니다.
*   **응답**: 페이징된 `MatchedMentorProfileDto` 목록 반환.

<p align="center">
  <img src="https://github.com/user-attachments/assets/dca5834a-c4ea-4f36-9a53-be36603dea3e" alt="신청한 매칭 상세 조회" width="70%" />
</p>

### 멘토 정보에 Contact Link 포함

*   **변경 사항**: 멘티가 신청한 매칭 목록 조회 시 반환되는 멘토 정보(`MatchedMentorProfileDto.MentorDto`)에 `contactLink` 필드를 추가했습니다.
*   **구현**: `MenteeProfileService`의 매핑 로직(`mapToMentorDto`)에서 멘토 객체의 `contactLink` 값을 가져와 DTO에 포함하도록 수정했습니다.

## ✅ 체크리스트

- [x] 코드 점검 완료
- [x] 테스트 통과
- [x] 문서/주석 최신화

## 📚 기타

-   "나의 활동 내역 more-details"에 내가 신청한 매칭(`my-matches`) 타입이 추가되었습니다.
-   신청한 매칭 조회 시 멘토의 연락 링크 정보(`contactLink`)를 확인할 수 있습니다.