### PR TITLE
[feat] 주간 인기 게시글 조회 기능 추가 & [refactor] DTO 클래스명 변경

### DIFF
--- a/src/main/java/com/team05/linkup/domain/community/api/BookmarkController.java
+++ b/src/main/java/com/team05/linkup/domain/community/api/BookmarkController.java
@@ -4,7 +4,7 @@ import com.team05.linkup.common.dto.ApiResponse;
 import com.team05.linkup.common.dto.UserPrincipal;
 import com.team05.linkup.common.enums.ResponseCode;
 import com.team05.linkup.domain.community.application.BookmarkService;
-import com.team05.linkup.domain.community.dto.BookmarkStatusResponse;
+import com.team05.linkup.domain.community.dto.BookmarkStatusResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -33,7 +33,7 @@ public class BookmarkController {
      */
     @Operation(summary = "게시글 북마크 토글", description = "특정 커뮤니티 게시글의 북마크 상태를 변경(토글).")
     @PostMapping("{communityId}/bookmark")
-    public ResponseEntity<ApiResponse<BookmarkStatusResponse>> toggleBookmark(
+    public ResponseEntity<ApiResponse<BookmarkStatusResponseDTO>> toggleBookmark(
             @PathVariable String communityId,
             @AuthenticationPrincipal UserPrincipal userPrincipal
     ) {
@@ -49,7 +49,7 @@ public class BookmarkController {
         boolean isBookmarked = bookmarkService.toggleBookmark(provider, providerId, communityId);
 
         // 성공 응답 반환 (최종 상태 포함)
-        return ResponseEntity.ok(ApiResponse.success(new BookmarkStatusResponse(isBookmarked)));
+        return ResponseEntity.ok(ApiResponse.success(new BookmarkStatusResponseDTO(isBookmarked)));
     }
 
 }

--- a/src/main/java/com/team05/linkup/domain/community/api/CommunityController.java
+++ b/src/main/java/com/team05/linkup/domain/community/api/CommunityController.java
@@ -7,7 +7,8 @@ import com.team05.linkup.domain.community.application.CommunityImageService;
 import com.team05.linkup.domain.community.application.CommunityService;
 import com.team05.linkup.domain.community.domain.CommunityCategory;
 import com.team05.linkup.domain.community.dto.CommunityDto;
-import com.team05.linkup.domain.community.dto.CommunitySummaryResponse;
+import com.team05.linkup.domain.community.dto.CommunitySummaryResponseDTO;
+import com.team05.linkup.domain.community.dto.CommunityWeeklyPopularDTO;
 import com.team05.linkup.domain.community.dto.ImageDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -57,10 +58,10 @@ public class CommunityController {
      */
     @GetMapping("/list")
     @Operation(summary = "게시글 목록 조회", description = "카테고리별로 필터링된 커뮤니티 게시물의 페이지별 목록을 검색합니다.")
-    public ResponseEntity<ApiResponse<Page<CommunitySummaryResponse>>> getCommunityList(
+    public ResponseEntity<ApiResponse<Page<CommunitySummaryResponseDTO>>> getCommunityList(
             @RequestParam(required = false) CommunityCategory category, // Enum으로 직접 받기
             @PageableDefault(size = 5, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        Page<CommunitySummaryResponse> communityPage = communityService.findCommunities(category, pageable);
+        Page<CommunitySummaryResponseDTO> communityPage = communityService.findCommunities(category, pageable);
         return ResponseEntity.ok(ApiResponse.success(communityPage));
     }
 
@@ -68,19 +69,38 @@ public class CommunityController {
      * 최근 활동을 기준으로 인기 커뮤니티 게시물 목록을 검색
      * 인기도는 일반적으로 특정 기간의 조회수, 좋아요 수, 작성일을 기준으로 결정
      *
-     * @param limit 반환할 인기 게시물의 최대 개수(기본값: 3개).
-     * @param day 인기도를 평가할 지난 일 수(기본값: 7개).
+     * @param limit 반환할 인기 게시물의 최대 개수(기본값: 2개).
+     * @param day 인기도를 평가할 지난 일 수(기본값: 2일).
      * @return CommunitySummaryResponse DTO 목록을 포함하는 ApiResponse를 포함하는 ResponseEntity.
      * URL 예시: GET /v1/community/popular?limit=5&day=14
      */
     @GetMapping("/popular")
     @Operation(summary = "인기 게시글 조회", description = "최근 활동을 기준으로 인기 커뮤니티 게시물 목록을 검색합니다.")
-    public ResponseEntity<ApiResponse<List<CommunitySummaryResponse>>> getPopularCommunities(
-            @RequestParam(defaultValue = "3") int limit,
-            @RequestParam(defaultValue = "7") int day) {
-        List<CommunitySummaryResponse> popularCommunities = communityService.findPopularCommunities(limit, day);
+    public ResponseEntity<ApiResponse<List<CommunitySummaryResponseDTO>>> getPopularCommunities(
+            @RequestParam(defaultValue = "2") int limit,
+            @RequestParam(defaultValue = "2") int day) {
+        List<CommunitySummaryResponseDTO> popularCommunities = communityService.findPopularCommunities(limit, day);
         return ResponseEntity.ok(ApiResponse.success(popularCommunities));
     }
+
+    /**
+     * 최근 활동을 기준으로 인기 커뮤니티 게시물 목록을 검색
+     * 인기도는 일반적으로 특정 기간의 조회수, 좋아요 수, 작성일을 기준으로 결정
+     *
+     * @param limit 반환할 인기 게시물의 최대 개수(기본값: 5개).
+     * @param day 인기도를 평가할 지난 일 수(기본값: 7일).
+     * @return CommunityWeeklyPopular DTO 목록을 포함하는 ApiResponse를 포함하는 ResponseEntity.
+     * URL 예시: GET /v1/community/weekly-popular?limit=7&day=7
+     */
+    @GetMapping("/weekly-popular")
+    @Operation(summary = "주간 인기 게시글 조회", description = "최근 활동을 기준으로 인기 커뮤니티 게시물(제목과 카테고리) 목록을 검색합니다.")
+    public ResponseEntity<ApiResponse<List<CommunityWeeklyPopularDTO>>> getWeeklyPopularCommunities(
+            @RequestParam(defaultValue = "5") int limit,
+            @RequestParam(defaultValue = "7") int day) {
+        List<CommunityWeeklyPopularDTO> popularCommunities = communityService.findWeeklyPopularCommunities(limit, day);
+        return ResponseEntity.ok(ApiResponse.success(popularCommunities));
+    }
+
 
     /**
      * 키워드를 사용하여 커뮤니티 게시글을 검색합니다.
@@ -93,11 +113,11 @@ public class CommunityController {
      */
     @GetMapping("/search")
     @Operation(summary = "게시글 검색", description = "키워드로 게시글을 검색합니다.")
-    public ResponseEntity<ApiResponse<Page<CommunitySummaryResponse>>> searchCommunityList(
+    public ResponseEntity<ApiResponse<Page<CommunitySummaryResponseDTO>>> searchCommunityList(
             @RequestParam String keyword, // 검색어는 필수로 받음
             // PageableDefault는 /list 와 동일하게 유지하거나 검색 결과에 맞게 조정
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        Page<CommunitySummaryResponse> searchResultPage = communityService.searchCommunities(keyword, pageable);
+        Page<CommunitySummaryResponseDTO> searchResultPage = communityService.searchCommunities(keyword, pageable);
         return ResponseEntity.ok(ApiResponse.success(searchResultPage));
     }
 

--- a/src/main/java/com/team05/linkup/domain/community/api/LikeController.java
+++ b/src/main/java/com/team05/linkup/domain/community/api/LikeController.java
@@ -4,7 +4,7 @@ import com.team05.linkup.common.dto.ApiResponse;
 import com.team05.linkup.common.dto.UserPrincipal;
 import com.team05.linkup.common.enums.ResponseCode;
 import com.team05.linkup.domain.community.application.LikeService;
-import com.team05.linkup.domain.community.dto.LikeStatusResponse;
+import com.team05.linkup.domain.community.dto.LikeStatusResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -33,7 +33,7 @@ public class LikeController {
      */
     @Operation(summary = "게시글 좋아요 토글", description = "특정 커뮤니티 게시글의 좋아요 상태를 변경(토글)합니다.")
     @PostMapping
-    public ResponseEntity<ApiResponse<LikeStatusResponse>> toggleLike(
+    public ResponseEntity<ApiResponse<LikeStatusResponseDTO>> toggleLike(
             @PathVariable String communityId,
             @AuthenticationPrincipal UserPrincipal userPrincipal
     ) {
@@ -47,6 +47,6 @@ public class LikeController {
 
 
         boolean liked = likeService.toggleLike(provider, providerId, communityId);
-        return ResponseEntity.ok(ApiResponse.success(new LikeStatusResponse(liked)));
+        return ResponseEntity.ok(ApiResponse.success(new LikeStatusResponseDTO(liked)));
     }
 }

--- a/src/main/java/com/team05/linkup/domain/community/dto/BookmarkStatusResponseDTO.java
+++ b/src/main/java/com/team05/linkup/domain/community/dto/BookmarkStatusResponseDTO.java
@@ -5,5 +5,5 @@ package com.team05.linkup.domain.community.dto;
  *
  * @param bookmarked 북마크 상태 (true: 북마크됨, false: 북마크 안됨)
  */
-public record BookmarkStatusResponse(boolean bookmarked) {
+public record BookmarkStatusResponseDTO(boolean bookmarked) {
 }

--- a/src/main/java/com/team05/linkup/domain/community/dto/CommunitySummaryResponseDTO.java
+++ b/src/main/java/com/team05/linkup/domain/community/dto/CommunitySummaryResponseDTO.java
@@ -15,9 +15,11 @@ import java.time.ZonedDateTime;
  * @param createdAt 게시물이 작성된 날짜 및 시간.
  * @param viewCount 게시물이 받은 조회수.
  * @param likeCount 게시물이 받은 좋아요 수.
+ * @param content 게시물 내용.
+ * @param profileImageUrl 게시물을 만든 사용자의 프로필 이미지 URL.
  * @param commentCount 게시물과 연결된 총 댓글 수.
  */
-public record CommunitySummaryResponse(
+public record CommunitySummaryResponseDTO(
         String id,
         String nickname,
         String title,
@@ -25,6 +27,8 @@ public record CommunitySummaryResponse(
         ZonedDateTime createdAt,
         Long viewCount,
         Long likeCount,
+        String content,
+        String profileImageUrl,
         Long commentCount
 ) {
 }

--- a/src/main/java/com/team05/linkup/domain/community/dto/CommunityWeeklyPopularDTO.java
+++ b/src/main/java/com/team05/linkup/domain/community/dto/CommunityWeeklyPopularDTO.java
@@ -1,0 +1,18 @@
+package com.team05.linkup.domain.community.dto;
+
+import com.team05.linkup.domain.community.domain.CommunityCategory;
+
+
+/**
+ * 커뮤니티 주간 인기 게시글 요약 뷰를 나타내는 데이터 전송 객체(DTO).
+ *
+ * @param id 커뮤니티 게시물의 고유 ID.
+ * @param title 커뮤니티 게시물의 제목.
+ * @param category 커뮤니티 게시물의 카테고리.
+ */
+public record CommunityWeeklyPopularDTO(
+        String id,
+        String title,
+        CommunityCategory category
+) {
+}

--- a/src/main/java/com/team05/linkup/domain/community/dto/LikeStatusResponse.java
+++ b/src/main/java/com/team05/linkup/domain/community/dto/LikeStatusResponse.java
@@ -1,4 +1,0 @@
-package com.team05.linkup.domain.community.dto;
-
-public record LikeStatusResponse(boolean liked) {
-}

--- a/src/main/java/com/team05/linkup/domain/community/dto/LikeStatusResponseDTO.java
+++ b/src/main/java/com/team05/linkup/domain/community/dto/LikeStatusResponseDTO.java
@@ -1,0 +1,4 @@
+package com.team05.linkup.domain.community.dto;
+
+public record LikeStatusResponseDTO(boolean liked) {
+}


### PR DESCRIPTION
## ✨ **PR 종류**

* [x] 기능 추가
* [ ] 버그 수정
* [x] 리팩토링
* [ ] 문서 수정
* [ ] 기타

## 🛠️ **작업 요약**

커뮤니티의 주간 인기 게시글을 조회하는 기능을 새롭게 추가하고, 기존 DTO 클래스들의 명칭을 일관성 있게 변경했습니다. 또한, `CommunitySummaryResponseDTO`에 `content`와 `profileImageUrl` 필드를 추가하여 게시글 요약 정보의 상세성을 높였습니다.
![image](https://github.com/user-attachments/assets/95d164d9-c511-4010-b9b5-298882c2e5c2)
![image](https://github.com/user-attachments/assets/510a0d91-0a01-4ba8-b2e5-ed9c4a9aed5d)

![image](https://github.com/user-attachments/assets/0b008df3-1c19-43f5-9987-467662b1717e)
![image](https://github.com/user-attachments/assets/7c5667f2-3a39-4c0c-ad43-40c9d2dfe349)

## 📝 **작업 상세**

1.  **주간 인기 게시글 조회 기능 추가 (`/v1/community/weekly-popular`)**
    * **API:** `GET /v1/community/weekly-popular`
    * **기능:** 최근 `day`일 동안 작성된 게시글 중 조회수, 좋아요 수, 최신순으로 정렬된 상위 `limit`개의 인기 게시글 목록(ID, 제목, 카테고리)을 조회합니다.
    * **구현:**
        * `CommunityController`: `getWeeklyPopularCommunities` 메소드 및 `@GetMapping("/weekly-popular")` 엔드포인트를 추가했습니다.
            * `@RequestParam(defaultValue = "5") int limit`: 반환할 인기 게시물의 최대 개수입니다.
            * `@RequestParam(defaultValue = "7") int day`: 인기도를 평가할 지난 일 수입니다.
        * `CommunityService`: `findWeeklyPopularCommunities` 메소드를 구현했습니다.
            * 조회 시작 시점(`ZonedDateTime.now().minusDays(day)`)을 계산합니다.
            * 결과 개수 제한을 위한 `PageRequest.of(0, limit)`을 설정합니다.
            * `communityRepository.findWeeklyPopular(daysAgo, topLimit)`를 호출하여 `List<CommunityWeeklyPopularDTO>`를 반환합니다.
        * `CommunityRepository`: `findWeeklyPopular` JPQL 쿼리 및 인터페이스 메소드를 추가했습니다.
            * JPQL: `SELECT new com.team05.linkup.domain.community.dto.CommunityWeeklyPopularDTO(c.id, c.title, c.category) FROM Community c WHERE c.createdAt > :startDate ORDER BY c.viewCount DESC, c.likeCount DESC, c.createdAt DESC`
    * **응답:** `ResponseEntity<ApiResponse<List<CommunityWeeklyPopularDTO>>>` 형태로 인기 게시글 목록을 반환합니다.

2.  **DTO 클래스명 변경 (일관성 및 명확성 향상)**
    * `LikeStatusResponse` -> `LikeStatusResponseDTO` 로 변경하고, `LikeController`에서 이를 사용하도록 수정했습니다.
    * `CommunitySummaryResponse` -> `CommunitySummaryResponseDTO` 로 변경했습니다.
    * `BookmarkStatusResponse` -> `BookmarkStatusResponseDTO` 로 변경하고, `BookmarkController`에서 이를 사용하도록 수정했습니다.

3.  **`CommunitySummaryResponseDTO` 필드 추가**
    * `String content`: 게시글의 내용을 포함하도록 필드를 추가했습니다.
    * `String profileImageUrl`: 게시글 작성자의 프로필 이미지 URL을 포함하도록 필드를 추가했습니다.

4.  **`CommunityRepository` JPQL 업데이트**
    * 기존 게시글 조회 관련 JPQL 쿼리들에서 `CommunitySummaryResponseDTO`에 새로 추가된 `content` 및 `profileImageUrl` 필드를 조회하여 DTO에 매핑하도록 수정했습니다.

## ✅ **체크리스트**

* [x] 코드 점검 완료
* [x] 테스트 통과 
* [x] 문서/주석 최신화 (`@Operation` 어노테이션 추가, 서비스 메소드 JavaDoc 작성 등)

## 📚 **기타**

* 주간 인기글 조회 API (`/v1/community/weekly-popular`)는 `limit`과 `day` 파라미터를 통해 조회 게시글 수와 기간을 유동적으로 조절할 수 있습니다.
* DTO 클래스명에 일관되게 `DTO` 접미사를 추가하여 코드의 가독성과 명명 규칙의 통일성을 개선했습니다.

---