### PR TITLE
[feat] 로그인 응답결과 기능 && [refactor] 컨트롤러 응답 결과 개선

### DIFF
--- a/src/main/java/com/team05/linkup/common/enums/ResponseCode.java
+++ b/src/main/java/com/team05/linkup/common/enums/ResponseCode.java
@@ -20,6 +20,7 @@ public enum ResponseCode {
     INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "요청 값의 타입이 올바르지 않습니다."),
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
+    TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "요청을 기다리다 서버에서 타임아웃하였습니다"),
 
     // 커뮤니티 관련 오류 (예시)
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시글을 찾을 수 없습니다."),

--- a/src/main/java/com/team05/linkup/common/util/ApiUtils.java
+++ b/src/main/java/com/team05/linkup/common/util/ApiUtils.java
@@ -9,7 +9,6 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.time.Duration;
 import java.util.Optional;
 
 @Component
@@ -17,7 +16,7 @@ public class ApiUtils {
     private static final Logger logger = LogManager.getLogger(ApiUtils.class);
 
     private static final HttpClient client = HttpClient.newBuilder()
-            .connectTimeout(Duration.ofSeconds(5))
+//            .connectTimeout(Duration.ofSeconds(10))
             .build();
 
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -32,7 +31,7 @@ public class ApiUtils {
 
             HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
                     .uri(URI.create(apiUrl))
-                    .timeout(Duration.ofSeconds(5))
+//                    .timeout(Duration.ofSeconds(10))
                     .header("Accept", "application/json")
                     .header("Content-Type", "application/json");
 

--- a/src/main/java/com/team05/linkup/domain/community/api/AiCommentController.java
+++ b/src/main/java/com/team05/linkup/domain/community/api/AiCommentController.java
@@ -26,13 +26,16 @@ public class AiCommentController {
     @GetMapping("/ai/{communityId}")
     @Operation(summary = "제미니 답변", description = "이벤트 리스너로 등록된 답변")
     public ResponseEntity<ApiResponse<AiCommentResponseDTO>> AiViewController(@AuthenticationPrincipal UserPrincipal userPrincipal,
-                                                                              @PathVariable String communityId) throws Exception {
-
-        if (userPrincipal == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(ApiResponse.error(ResponseCode.UNAUTHORIZED));
+                                                                              @PathVariable String communityId) {
+     try {
+            if (userPrincipal == null) {
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                        .body(ApiResponse.error(ResponseCode.UNAUTHORIZED));
+            }
+            AiCommentResponseDTO data = aiCommentService.getAiComment(communityId);
+            return ResponseEntity.ok(ApiResponse.success(data));
+        } catch (Exception e) {
+            return ResponseEntity.ok(ApiResponse.error(ResponseCode.INTERNAL_SERVER_ERROR));
         }
-        AiCommentResponseDTO data = aiCommentService.getAiComment(communityId);
-        return ResponseEntity.ok(ApiResponse.success(data));
     }
 }

--- a/src/main/java/com/team05/linkup/domain/community/application/AiCommentViewServiceImpl.java
+++ b/src/main/java/com/team05/linkup/domain/community/application/AiCommentViewServiceImpl.java
@@ -3,15 +3,24 @@ package com.team05.linkup.domain.community.application;
 import com.team05.linkup.domain.community.dto.AiCommentResponseDTO;
 import com.team05.linkup.domain.community.infrastructure.CustomAiCommentRepositoryImpl;
 import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class AiCommentViewServiceImpl implements AiCommentViewService {
     private final CustomAiCommentRepositoryImpl customAiCommentRepository;
+    private static final Logger logger = LogManager.getLogger(AiCommentViewServiceImpl.class);
     @Override
     public AiCommentResponseDTO getAiComment(String communityId) throws Exception {
-        String comment = customAiCommentRepository.findCommentByText(communityId);
-        return new AiCommentResponseDTO(comment);
+        try {
+            String comment = customAiCommentRepository.findCommentByText(communityId);
+            return new AiCommentResponseDTO(comment);
+        } catch (Exception e) {
+            logger.error("Error in getAiComment: {}", e.getMessage());
+            throw new Exception("Error in getAiComment: " + e.getMessage(), e);
+        }
+
     }
 }

--- a/src/main/java/com/team05/linkup/domain/mentoring/api/AiMatchingController.java
+++ b/src/main/java/com/team05/linkup/domain/mentoring/api/AiMatchingController.java
@@ -4,10 +4,10 @@ import com.team05.linkup.common.dto.ApiResponse;
 import com.team05.linkup.common.dto.UserPrincipal;
 import com.team05.linkup.common.enums.ResponseCode;
 import com.team05.linkup.common.exception.DuplicateMentoringMatchException;
-import com.team05.linkup.common.util.JwtUtils;
-import com.team05.linkup.domain.mentoring.dto.AiMatchingResponseDTO;
+import com.team05.linkup.common.exception.UserNotfoundException;
 import com.team05.linkup.domain.mentoring.application.AiMatchingListServiceImpl;
 import com.team05.linkup.domain.mentoring.application.AiMatchingSelectorServiceImpl;
+import com.team05.linkup.domain.mentoring.dto.AiMatchingResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +21,6 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @Tag(name = "ai 매칭 api입니다")
 public class AiMatchingController {
-    private final JwtUtils jwtUtils;
     private final AiMatchingListServiceImpl aiMatchingServiceImpl;
     private final AiMatchingSelectorServiceImpl aiMatchingSelectorServiceImpl;
 
@@ -38,9 +37,11 @@ public class AiMatchingController {
                         .status(ResponseCode.UNAUTHORIZED.getStatus())
                         .body(ApiResponse.error(ResponseCode.UNAUTHORIZED));
             }
-                AiMatchingResponseDTO responseDTO = aiMatchingServiceImpl.matchMentor(provider,providerId);
+                AiMatchingResponseDTO responseDTO = aiMatchingServiceImpl.matchMentor(userPrincipal);
                 return ResponseEntity.ok(ApiResponse.success(responseDTO));
 
+        } catch (UserNotfoundException e){
+            return ResponseEntity.ok(ApiResponse.error(ResponseCode.ENTITY_NOT_FOUND));
         }
         catch (Exception e) {
             return ResponseEntity.ok(ApiResponse.error(ResponseCode.INTERNAL_SERVER_ERROR));
@@ -61,11 +62,14 @@ public class AiMatchingController {
                         .body(ApiResponse.error(ResponseCode.UNAUTHORIZED));
             }
 
-            aiMatchingSelectorServiceImpl.matchingMentor(provider, providerId, nickname);
+            aiMatchingSelectorServiceImpl.matchingMentor(userPrincipal, nickname);
             return ResponseEntity.ok(ApiResponse.success());
         } catch (DuplicateMentoringMatchException e) {
             return ResponseEntity.ok(ApiResponse.error(ResponseCode.INVALID_INPUT_VALUE));
+        } catch (UserNotfoundException e){
+            return ResponseEntity.ok(ApiResponse.error(ResponseCode.ENTITY_NOT_FOUND));
         }
+
         catch (Exception e) {
             return ResponseEntity.ok(ApiResponse.error(ResponseCode.INTERNAL_SERVER_ERROR));
         }

--- a/src/main/java/com/team05/linkup/domain/mentoring/api/AiMatchingController.java
+++ b/src/main/java/com/team05/linkup/domain/mentoring/api/AiMatchingController.java
@@ -16,6 +16,8 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.concurrent.TimeoutException;
+
 @RestController
 @RequestMapping("/v1/matching")
 @RequiredArgsConstructor
@@ -40,6 +42,8 @@ public class AiMatchingController {
                 AiMatchingResponseDTO responseDTO = aiMatchingServiceImpl.matchMentor(userPrincipal);
                 return ResponseEntity.ok(ApiResponse.success(responseDTO));
 
+        } catch (TimeoutException e) {
+            return ResponseEntity.ok(ApiResponse.error(ResponseCode.TIMEOUT));
         } catch (UserNotfoundException e){
             return ResponseEntity.ok(ApiResponse.error(ResponseCode.ENTITY_NOT_FOUND));
         }

--- a/src/main/java/com/team05/linkup/domain/mentoring/application/AiMatchingListServiceImpl.java
+++ b/src/main/java/com/team05/linkup/domain/mentoring/application/AiMatchingListServiceImpl.java
@@ -1,5 +1,6 @@
 package com.team05.linkup.domain.mentoring.application;
 
+import com.team05.linkup.common.dto.UserPrincipal;
 import com.team05.linkup.common.exception.UserNotfoundException;
 import com.team05.linkup.common.util.ApiUtils;
 import com.team05.linkup.domain.enums.Interest;
@@ -23,17 +24,16 @@ import java.util.stream.Collectors;
 public class AiMatchingListServiceImpl implements AiMatchingService {
     private static final Logger logger = LogManager.getLogger();
     private final UserRepository userRepository;
-//    private final CustomUserRepositoryImpl customUserRepositoryImpl;
     private final ApiUtils apiUtils;
     private final RecommendationLogic recommendationLogic;
 
     @Override
-    public AiMatchingResponseDTO matchMentor(String provider, String providerId) {
+    public AiMatchingResponseDTO matchMentor(UserPrincipal userPrincipal){
         try {
+            String provider = userPrincipal.provider();
+            String providerId = userPrincipal.providerId();
             ProfileTagInterestDTO result = userRepository.findProfileTagAndInterestByProviderAndProviderId(provider,providerId);
-//            if (result[0] == null || result[1] == null ) {
-//                throw new UserNotfoundException("User profile data not found");
-//            }
+//
             logger.debug(result);
 
             String myProfileTag = result.profileTag();

--- a/src/main/java/com/team05/linkup/domain/mentoring/application/AiMatchingListServiceImpl.java
+++ b/src/main/java/com/team05/linkup/domain/mentoring/application/AiMatchingListServiceImpl.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 @Service
@@ -28,7 +29,7 @@ public class AiMatchingListServiceImpl implements AiMatchingService {
     private final RecommendationLogic recommendationLogic;
 
     @Override
-    public AiMatchingResponseDTO matchMentor(UserPrincipal userPrincipal){
+    public AiMatchingResponseDTO matchMentor(UserPrincipal userPrincipal) throws TimeoutException {
         try {
             String provider = userPrincipal.provider();
             String providerId = userPrincipal.providerId();
@@ -52,11 +53,12 @@ public class AiMatchingListServiceImpl implements AiMatchingService {
                                 (String) obj[4],   // nickname
                                 (String) obj[5],   // profileTag
                                 (String) obj[6],   // profileImageUrl
-                                (String) obj[7]    // providerId
+                                (String) obj[7],    // providerId
+                                (String) obj[8]
                             )).collect(Collectors.toList());
 
             AiMatchingRequestDTO requestDTO = new AiMatchingRequestDTO(myProfileTag, otherProfiles);
-            String url = "http://localhost:5000/word-similarity";
+            String url = "https://aibe1-project2-team05-embedding.fly.dev/word-similarity";
 
             Optional<AiMatchingResponseDTO> responseOpt = apiUtils.getApiResponse(url, "POST", requestDTO, AiMatchingResponseDTO.class);
 

--- a/src/main/java/com/team05/linkup/domain/mentoring/application/AiMatchingSelectorServiceImpl.java
+++ b/src/main/java/com/team05/linkup/domain/mentoring/application/AiMatchingSelectorServiceImpl.java
@@ -1,5 +1,6 @@
 package com.team05.linkup.domain.mentoring.application;
 
+import com.team05.linkup.common.dto.UserPrincipal;
 import com.team05.linkup.common.exception.DuplicateMentoringMatchException;
 import com.team05.linkup.common.exception.UserNotfoundException;
 import com.team05.linkup.domain.enums.MentoringStatus;
@@ -22,8 +23,10 @@ public class AiMatchingSelectorServiceImpl implements MatchingService {
     private final CustomUserRepositoryImpl customUserRepositoryImpl;
 
     @Override
-    public void matchingMentor(String provider, String providerId, String nickname) throws Exception {
+    public void matchingMentor(UserPrincipal userPrincipal, String nickname) throws Exception {
         try {
+            String provider = userPrincipal.provider();
+            String providerId = userPrincipal.providerId();
             User mentee = userRepository.findByProviderAndProviderId(provider, providerId)
                     .orElseThrow(() -> new UserNotfoundException("Mentee not found"));
 

--- a/src/main/java/com/team05/linkup/domain/mentoring/application/AiMatchingService.java
+++ b/src/main/java/com/team05/linkup/domain/mentoring/application/AiMatchingService.java
@@ -1,7 +1,8 @@
 package com.team05.linkup.domain.mentoring.application;
 
+import com.team05.linkup.common.dto.UserPrincipal;
 import com.team05.linkup.domain.mentoring.dto.AiMatchingResponseDTO;
 
 public interface AiMatchingService {
-    AiMatchingResponseDTO matchMentor(String provider, String providerId);
+    AiMatchingResponseDTO matchMentor(UserPrincipal userPrincipal) throws Exception;
 }

--- a/src/main/java/com/team05/linkup/domain/mentoring/application/AiMatchingService.java
+++ b/src/main/java/com/team05/linkup/domain/mentoring/application/AiMatchingService.java
@@ -3,6 +3,8 @@ package com.team05.linkup.domain.mentoring.application;
 import com.team05.linkup.common.dto.UserPrincipal;
 import com.team05.linkup.domain.mentoring.dto.AiMatchingResponseDTO;
 
+import java.util.concurrent.TimeoutException;
+
 public interface AiMatchingService {
-    AiMatchingResponseDTO matchMentor(UserPrincipal userPrincipal) throws Exception;
+    AiMatchingResponseDTO matchMentor(UserPrincipal userPrincipal) throws Exception, TimeoutException;
 }

--- a/src/main/java/com/team05/linkup/domain/mentoring/application/MatchingService.java
+++ b/src/main/java/com/team05/linkup/domain/mentoring/application/MatchingService.java
@@ -1,5 +1,7 @@
 package com.team05.linkup.domain.mentoring.application;
 
+import com.team05.linkup.common.dto.UserPrincipal;
+
 public interface MatchingService {
-    void matchingMentor(String provider, String providerId, String nickname) throws Exception;
+    void matchingMentor(UserPrincipal userPrincipal, String nickname) throws Exception;
 }

--- a/src/main/java/com/team05/linkup/domain/mentoring/dto/AiMatchingRequestDTO.java
+++ b/src/main/java/com/team05/linkup/domain/mentoring/dto/AiMatchingRequestDTO.java
@@ -11,6 +11,7 @@ public record AiMatchingRequestDTO(String profileTag, List<OtherProfile> otherPr
                                 String nickname,
                                 String profileTag,
                                 String profileImageUrl,
-                                String providerId
+                                String providerId,
+                                String contactLink
                                ) {}
 }

--- a/src/main/java/com/team05/linkup/domain/user/api/AuthController.java
+++ b/src/main/java/com/team05/linkup/domain/user/api/AuthController.java
@@ -14,11 +14,16 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.Duration;
+import java.util.Map;
 
 @Tag(name = "Authentication", description = "인증 관련 API")
 @RestController
@@ -56,5 +61,21 @@ public class AuthController {
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
+    }
+
+    @GetMapping("/session-info")
+    public ResponseEntity<?> sessionInfo(@AuthenticationPrincipal OAuth2User principal,
+                                         Authentication authentication) {
+        if (principal == null || authentication == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(Map.of("loggedIn", false));
+        }
+
+        String socialType = ((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId();
+
+        return ResponseEntity.ok(Map.of(
+                "loggedIn", true,
+                "socialType", socialType
+        ));
     }
 }

--- a/src/main/java/com/team05/linkup/domain/user/api/RoleController.java
+++ b/src/main/java/com/team05/linkup/domain/user/api/RoleController.java
@@ -36,9 +36,6 @@ public class RoleController {
                         .body(ApiResponse.error(ResponseCode.UNAUTHORIZED));
             }
 
-            String providerId = userPrincipal.providerId();
-            String provider = userPrincipal.provider();
-
             modifyRoleServiceImpl.modifyRole(userPrincipal, roleRequestDTO.role());
             return ResponseEntity.ok(ApiResponse.success());
 

--- a/src/main/java/com/team05/linkup/domain/user/infrastructure/UserRepository.java
+++ b/src/main/java/com/team05/linkup/domain/user/infrastructure/UserRepository.java
@@ -48,7 +48,8 @@ public interface UserRepository extends JpaRepository<User, String> {
                        u.nickname,
                        u.profileTag,
                        u.profileImageUrl,
-                       u.providerId
+                       u.providerId,
+                       u.contactLink
         FROM User u, Area area, Sigungu sigungu
         WHERE u.providerId <> :providerId AND u.provider = :provider AND u.interest = :interest
     """)


### PR DESCRIPTION
## ✨ PR 종류

- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 🛠️ 작업 요약

- 로그인 시 프론트 응답결과 추가
- 컨트롤러 응답 결과 통일

## 📝 작업 상세

- 작업 1: 로그인시 루트 경로로 리다이렉트 되어 프론트에 명시적으로 /session-info api를 호출하여  응답 결과를 받을 수 있도록 기능을 추가했습니다
- 작업 2: 컨트롤러 응답 결과를 통일 했습니다

## ✅ 체크리스트

- [x] 코드 점검 완료
- [x] 테스트 통과
- [x] 문서/주석 최신화

## 📚 기타

- (선택사항)