### PR TITLE
[feat] Community 엔티티와 Tag 엔티티 간의 다대다 관계 구현, 인기 태그 조회 및 태그 필터링 기능 추가 & [refactor]  관련 DTO 및 Repository 조정

### DIFF
--- a/src/main/java/com/team05/linkup/domain/baseEntity/BaseEntity.java
+++ b/src/main/java/com/team05/linkup/domain/baseEntity/BaseEntity.java
@@ -8,22 +8,44 @@ import lombok.Getter;
 
 import java.time.ZonedDateTime;
 
+/**
+ * 모든 엔티티가 공통으로 상속받는 기본 엔티티 클래스입니다.
+ * 생성일시(createdAt)와 수정일시(updatedAt) 필드를 포함하며,
+ * JPA 생명주기 이벤트를 통해 자동으로 관리됩니다.
+ */
 @Getter
 @MappedSuperclass
 public abstract class BaseEntity {
 
+    /**
+     * 엔티티 생성 일시
+     * - 한 번 생성되면 변경되지 않도록 updatable = false 설정
+     * - null 값을 허용하지 않음
+     */
     @Column(updatable = false, nullable = false) // 생성 시간은 업데이트되면 안 됨
     private ZonedDateTime createdAt;
 
+    /**
+     * 엔티티 최종 수정 일시
+     * - null 값을 허용하지 않음
+     */
     @Column(nullable = false)
     private ZonedDateTime updatedAt;
 
+    /**
+     * 엔티티가 영속화되기 직전에 호출됩니다.
+     * createdAt과 updatedAt 필드를 현재 시간으로 초기화합니다.
+     */
     @PrePersist
     public void prePersist() {
         this.createdAt = ZonedDateTime.now();
         this.updatedAt = ZonedDateTime.now();
     }
 
+    /**
+     * 엔티티가 데이터베이스에 업데이트되기 직전에 호출됩니다.
+     * updatedAt 필드를 현재 시간으로 갱신합니다.
+     */
     @PreUpdate
     public void preUpdate() {
         this.updatedAt = ZonedDateTime.now();

--- a/src/main/java/com/team05/linkup/domain/community/api/CommunityController.java
+++ b/src/main/java/com/team05/linkup/domain/community/api/CommunityController.java
@@ -213,7 +213,7 @@ public class CommunityController {
 
         try {
             return ResponseEntity
-                    .ok(ApiResponse.success(communityService.updateCommunity(principal.providerId(), postId, request)));
+                    .ok(ApiResponse.success(communityService.updateCommunity(principal, postId, request)));
         } catch (IllegalArgumentException e) {
             return ResponseEntity
                     .status(HttpStatus.FORBIDDEN)
@@ -246,7 +246,7 @@ public class CommunityController {
         }
 
         try {
-            communityService.deleteCommunity(principal.providerId(), postId);
+            communityService.deleteCommunity(principal, postId);
             return ResponseEntity.ok(ApiResponse.success());
         } catch (IllegalArgumentException e) {
             return ResponseEntity

--- a/src/main/java/com/team05/linkup/domain/community/api/CommunityController.java
+++ b/src/main/java/com/team05/linkup/domain/community/api/CommunityController.java
@@ -6,10 +6,7 @@ import com.team05.linkup.common.enums.ResponseCode;
 import com.team05.linkup.domain.community.application.CommunityImageService;
 import com.team05.linkup.domain.community.application.CommunityService;
 import com.team05.linkup.domain.community.domain.CommunityCategory;
-import com.team05.linkup.domain.community.dto.CommunityDto;
-import com.team05.linkup.domain.community.dto.CommunitySummaryResponseDTO;
-import com.team05.linkup.domain.community.dto.CommunityWeeklyPopularDTO;
-import com.team05.linkup.domain.community.dto.ImageDto;
+import com.team05.linkup.domain.community.dto.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -44,6 +41,16 @@ public class CommunityController {
     private final CommunityService communityService;
     private final CommunityImageService communityImageService;
 
+
+
+    @GetMapping("/popular-tags")
+    @Operation(summary = "인기 태그 조회", description = "지정된 기간 동안 가장 많이 사용된 태그 목록을 반환합니다.")
+    public ResponseEntity<ApiResponse<List<TagDTO>>> getPopularTags(
+            @RequestParam(defaultValue = "5") int limit, // 상위 10개 태그
+            @RequestParam(defaultValue = "10") int days) {
+        List<TagDTO> popularTags = communityService.findPopularTags(limit, days);
+        return ResponseEntity.ok(ApiResponse.success(popularTags));
+    }
     /* -------------------------------------------------- 게시글 목록 조회 -------------------------------------------------- */
 
     /**
@@ -59,9 +66,10 @@ public class CommunityController {
     @GetMapping("/list")
     @Operation(summary = "게시글 목록 조회", description = "카테고리별로 필터링된 커뮤니티 게시물의 페이지별 목록을 검색합니다.")
     public ResponseEntity<ApiResponse<Page<CommunitySummaryResponseDTO>>> getCommunityList(
-            @RequestParam(required = false) CommunityCategory category, // Enum으로 직접 받기
+            @RequestParam(required = false) CommunityCategory category,
+            @RequestParam(required = false) String tag,
             @PageableDefault(size = 5, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        Page<CommunitySummaryResponseDTO> communityPage = communityService.findCommunities(category, pageable);
+        Page<CommunitySummaryResponseDTO> communityPage = communityService.findCommunities(category, tag, pageable);
         return ResponseEntity.ok(ApiResponse.success(communityPage));
     }
 

--- a/src/main/java/com/team05/linkup/domain/community/application/CommunityService.java
+++ b/src/main/java/com/team05/linkup/domain/community/application/CommunityService.java
@@ -5,10 +5,7 @@ import com.team05.linkup.domain.community.domain.Community;
 import com.team05.linkup.domain.community.domain.CommunityCategory;
 import com.team05.linkup.domain.community.domain.Image;
 import com.team05.linkup.domain.community.domain.Tag;
-import com.team05.linkup.domain.community.dto.CommunityCreatedEventDTO;
-import com.team05.linkup.domain.community.dto.CommunityDto;
-import com.team05.linkup.domain.community.dto.CommunitySummaryResponseDTO;
-import com.team05.linkup.domain.community.dto.CommunityWeeklyPopularDTO;
+import com.team05.linkup.domain.community.dto.*;
 import com.team05.linkup.domain.community.infrastructure.CommentRepository;
 import com.team05.linkup.domain.community.infrastructure.CommunityRepository;
 import com.team05.linkup.domain.community.infrastructure.ImageRepository;
@@ -91,6 +88,12 @@ public class CommunityService {
         return tags;
     }
 
+    public List<TagDTO> findPopularTags(int limit, int days) {
+        ZonedDateTime sinceDate = ZonedDateTime.now().minusDays(days);
+        Pageable pageable = PageRequest.of(0, limit);
+        return tagRepository.findPopularTagsSince(sinceDate, pageable);
+    }
+
     /**
      * 지정된 조건(카테고리 필터링, 페이징, 정렬)에 맞는 게시글 요약 목록을 조회합니다.
      * 이 메소드는 읽기 전용 트랜잭션으로 실행됩니다.
@@ -101,9 +104,14 @@ public class CommunityService {
      * 결과가 없을 경우 빈 Page 객체가 반환됩니다.
      * @see CommunityRepository#findCommunitySummaries(CommunityCategory, Pageable)
      */
-    public Page<CommunitySummaryResponseDTO> findCommunities(CommunityCategory category, Pageable pageable) {
+    public Page<CommunitySummaryResponseDTO> findCommunities(CommunityCategory category, String tagName, Pageable pageable) {
+        String trimmedTagName = null;
+        if (StringUtils.hasText(tagName)) {
+            trimmedTagName = tagName.trim();
+        }
         return communityRepository.findCommunitySummaries(
                 category,
+                trimmedTagName,
                 pageable
         );
     }

--- a/src/main/java/com/team05/linkup/domain/community/domain/Community.java
+++ b/src/main/java/com/team05/linkup/domain/community/domain/Community.java
@@ -5,8 +5,7 @@ import com.team05.linkup.domain.baseEntity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 /**
  * 커뮤니티 게시글 엔티티
@@ -15,42 +14,99 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
-@Builder
 @Table(name = "community")
 public class Community extends BaseEntity {
+
+    /**
+     * 게시글의 고유 식별자 (PK) - UUID 사용
+     */
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     @Column(length = 36, updatable = false, nullable = false)
     private String id;
 
+    /**
+     * 게시글 작성자 (User 엔티티와 다대일 관계)
+     */
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    /**
+     * 게시글 제목 (최대 100자)
+     */
     @Column(length = 100, nullable = false)
     private String title;
 
+    /**
+     * 게시글 카테고리 (Enum 타입)
+     */
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private CommunityCategory category;
 
-    @Column(name = "community_tag")
-    private String communityTag;
-
+    /**
+     * 게시글 내용 (긴 텍스트)
+     */
     @Lob
     @Column(nullable = false)
     private String content;
 
+    /**
+     * 조회수 (기본값 0)
+     */
     @Column(name = "view_count", nullable = false, columnDefinition = "BIGINT default 0")
     private Long viewCount = 0L;
 
-    @Column(name = "like_count", columnDefinition = "BIGINT")
-    @Builder.Default
+    /**
+     * 좋아요 수 (기본값 0)
+     */
+    @Column(name = "like_count", columnDefinition = "BIGINT default 0")
     private Long likeCount = 0L;
 
+    /**
+     * AI 자동 생성 댓글 (Community와 일대일 관계)
+     */
     @OneToOne(mappedBy = "community")
     private AiComment aiComment;
+
+
+    /**
+     * 게시글에 첨부된 이미지 목록 (Community와 일대다 관계)
+     */
+    @OneToMany(mappedBy = "community",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true)
+    private List<Image> images = new ArrayList<>();
+
+    /**
+     * 게시글에 연결된 태그 목록 (Community와 Tag는 다대다 관계)
+     */
+    @ManyToMany(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    @JoinTable(
+            name = "community_tag_join", // DB에 생성될 조인 테이블 이름
+            joinColumns = @JoinColumn(name = "community_id"), // 현재 엔티티(Community)를 참조하는 FK
+            inverseJoinColumns = @JoinColumn(name = "tag_id")  // 반대편 엔티티(Tag)를 참조하는 FK
+    )
+    private Set<Tag> tags = new HashSet<>();
+
+
+    // 빌더 패턴을 위한 생성자 (필요한 모든 필드 포함)
+    @Builder
+    public Community(String id, User user, String title, CommunityCategory category,
+                     String content, Long viewCount, Long likeCount, AiComment aiComment,
+                     List<Image> images, Set<Tag> tags) {
+        this.id = id;
+        this.user = user;
+        this.title = title;
+        this.category = category;
+        this.content = content;
+        this.viewCount = (viewCount == null) ? 0L : viewCount;
+        this.likeCount = (likeCount == null) ? 0L : likeCount;
+        this.aiComment = aiComment;
+        this.images = Objects.requireNonNullElseGet(images, ArrayList::new);
+        this.tags = Objects.requireNonNullElseGet(tags, HashSet::new);
+    }
 
     // 도메인 로직
     /**
@@ -59,13 +115,18 @@ public class Community extends BaseEntity {
      * @param title 게시글 제목
      * @param content 게시글 내용
      * @param category 게시글 카테고리
-     * @param communityTag 게시글 태그
+     * @param newTags 새로운 태그 Set (서비스 레이어에서 문자열 목록을 Tag 객체 Set으로 변환하여 전달)
      */
-    public void update(String title, String content, CommunityCategory category, String communityTag) {
+    public void update(String title, String content, CommunityCategory category, Set<Tag> newTags) {
         this.title = title;
         this.content = content;
         this.category = category;
-        this.communityTag = communityTag;
+
+        // 태그 업데이트: 기존 태그를 모두 지우고 새로운 태그로 교체하는 방식
+        this.tags.clear();
+        if (newTags != null) {
+            this.tags.addAll(newTags);
+        }
     }
 
     /**
@@ -91,12 +152,4 @@ public class Community extends BaseEntity {
         }
     }
 
-    /*
-    * 양-방향 이미지 필드
-    **/
-    @OneToMany(mappedBy = "community",
-            cascade = CascadeType.ALL,
-            orphanRemoval = true)
-    @Builder.Default                 // builder 사용 시 NPE 방지
-    private List<Image> images = new ArrayList<>();
 }

--- a/src/main/java/com/team05/linkup/domain/community/domain/Tag.java
+++ b/src/main/java/com/team05/linkup/domain/community/domain/Tag.java
@@ -1,0 +1,48 @@
+package com.team05.linkup.domain.community.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * 태그 정보를 나타내는 엔티티 클래스입니다.
+ * 각 태그는 고유한 이름을 가집니다.
+ * Community 엔티티와 다대다 관계를 맺습니다.
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Table(name = "tags", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_tag_name", columnNames = {"name"})
+})
+public class Tag {
+
+    /**
+     * 태그의 고유 식별자 (PK)
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * 태그의 이름
+     * - null이거나 비어있을 수 없음
+     * - 최대 15자 (조정 가능)
+     */
+    @Column(name = "name", length = 15, nullable = false)
+    private String name;
+
+    /**
+     * 이 태그를 사용하는 커뮤니티 게시글 목록
+     * - mappedBy: Community 엔티티의 'tags' 필드에 의해 관계가 관리됨을 명시
+     * - 선택 사항: Tag 엔티티에서 Community 목록을 직접 조회할 필요가 없다면 생략 가능
+     */
+    @ManyToMany(mappedBy = "tags") // Community 엔티티의 tags 필드에 의해 매핑됨
+    @Builder.Default
+    private Set<Community> communities = new HashSet<>();
+
+}

--- a/src/main/java/com/team05/linkup/domain/community/dto/CommunityDto.java
+++ b/src/main/java/com/team05/linkup/domain/community/dto/CommunityDto.java
@@ -1,6 +1,7 @@
 package com.team05.linkup.domain.community.dto;
 
 import com.team05.linkup.domain.community.domain.Community;
+import com.team05.linkup.domain.community.domain.Tag;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,6 +9,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * 커뮤니티 기능과 관련된 DTO 클래스들을 정의합니다.
@@ -27,7 +29,11 @@ public class CommunityDto {
         @NotBlank(message = "카테고리는 필수 입력값입니다.")
         private String category;
 
-        private String communityTag;
+        /**
+         * 게시글에 첨부할 태그 이름 목록입니다.
+         * 프론트엔드에서 "tags": ["tag1", "tag2"] 형태로 전송하는 것을 가정합니다.
+         */
+        private List<String> tags;
 
         @NotBlank(message = "내용은 필수 입력값입니다.")
         private String content;
@@ -63,7 +69,7 @@ public class CommunityDto {
         private String userId;
         private String title;
         private String category;
-        private String communityTag;
+        private List<String> tags;
         private String content;
         private ZonedDateTime createdAt;
         private ZonedDateTime updatedAt;
@@ -80,7 +86,7 @@ public class CommunityDto {
                     .userId(community.getUser().getId())
                     .title(community.getTitle())
                     .category(community.getCategory().name())
-                    .communityTag(community.getCommunityTag())
+                    .tags(community.getTags().stream().map(Tag::getName).collect(Collectors.toList()))
                     .content(community.getContent())
                     .createdAt(community.getCreatedAt())
                     .updatedAt(community.getUpdatedAt())
@@ -101,7 +107,7 @@ public class CommunityDto {
         private String profileImageUrl;
         private String title;
         private String category;
-        private String communityTag;
+        private List<String> tags;
         private String content;
         private int viewCount;     // Long에서 int로 변환
         private int likeCount;     // Long에서 int로 변환
@@ -126,12 +132,34 @@ public class CommunityDto {
         private String profileImageUrl;
         private String title;
         private String category;
-        private String communityTag;
+        private List<String> tags;
         private String content;
         private int viewCount;
         private int likeCount;
         private int commentCount;
         private ZonedDateTime createdAt;
+
+        // 서비스에서 Community 엔티티를 이 DTO로 변환하는 로직 필요
+        public static CommunitySummaryResponse fromEntity(Community community, int commentCount) {
+            String preview = community.getContent();
+            if (preview != null && preview.length() > 100) {
+                preview = preview.substring(0, 100) + "...";
+            }
+
+            return CommunitySummaryResponse.builder()
+                    .id(community.getId())
+                    .nickname(community.getUser().getNickname())
+                    .profileImageUrl(community.getUser().getProfileImageUrl())
+                    .title(community.getTitle())
+                    .category(community.getCategory().name())
+                    .tags(community.getTags().stream().map(Tag::getName).collect(Collectors.toList()))
+                    .content(preview)
+                    .viewCount(community.getViewCount().intValue())
+                    .likeCount(community.getLikeCount().intValue())
+                    .commentCount(commentCount)
+                    .createdAt(community.getCreatedAt())
+                    .build();
+        }
 
         /**
          * 미리보기용 내용 생성 (최대 100자)

--- a/src/main/java/com/team05/linkup/domain/community/dto/TagDTO.java
+++ b/src/main/java/com/team05/linkup/domain/community/dto/TagDTO.java
@@ -1,0 +1,6 @@
+package com.team05.linkup.domain.community.dto;
+
+public record TagDTO(
+        String name
+) {
+}

--- a/src/main/java/com/team05/linkup/domain/community/infrastructure/CommunityRepository.java
+++ b/src/main/java/com/team05/linkup/domain/community/infrastructure/CommunityRepository.java
@@ -27,9 +27,11 @@ public interface CommunityRepository extends JpaRepository<Community, String>, C
             "u.profileImageUrl, " +
             "CAST((SELECT COUNT(cmt.id) FROM Comment cmt WHERE cmt.communityId = c.id) AS Long) AS commentCount) " +
             "FROM Community c JOIN c.user u " +
-            "WHERE (:category IS NULL OR c.category = :category)")
+            "WHERE (:category IS NULL OR c.category = :category) " +
+            "  AND (:tagName IS NULL OR EXISTS (SELECT t_sub FROM c.tags t_sub WHERE t_sub.name = :tagName))")
     Page<CommunitySummaryResponseDTO> findCommunitySummaries(
             @Param("category") CommunityCategory category,
+            @Param("tagName") String tagName,
             Pageable pageable);
 
     /**

--- a/src/main/java/com/team05/linkup/domain/community/infrastructure/CommunityRepositoryCustom.java
+++ b/src/main/java/com/team05/linkup/domain/community/infrastructure/CommunityRepositoryCustom.java
@@ -2,6 +2,7 @@ package com.team05.linkup.domain.community.infrastructure;
 
 import com.team05.linkup.domain.community.domain.Community;
 import com.team05.linkup.domain.community.domain.CommunityCategory;
+import com.team05.linkup.domain.community.domain.Tag;
 import com.team05.linkup.domain.user.dto.CommunityQnAPostDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -37,7 +38,7 @@ public interface CommunityRepositoryCustom {
             String nickname,
             CommunityCategory category,
             String userRole,
-            String tag,
+            Tag tag,
             Pageable pageable
     );
 }

--- a/src/main/java/com/team05/linkup/domain/community/infrastructure/CommunityRepositoryCustomImpl.java
+++ b/src/main/java/com/team05/linkup/domain/community/infrastructure/CommunityRepositoryCustomImpl.java
@@ -1,11 +1,9 @@
 package com.team05.linkup.domain.community.infrastructure;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.team05.linkup.domain.community.domain.Community;
-import com.team05.linkup.domain.community.domain.CommunityCategory;
-import com.team05.linkup.domain.community.domain.QComment;
-import com.team05.linkup.domain.community.domain.QCommunity;
+import com.team05.linkup.domain.community.domain.*;
 import com.team05.linkup.domain.user.domain.QUser;
 import com.team05.linkup.domain.user.dto.CommunityQnAPostDTO;
 import com.team05.linkup.domain.user.dto.QCommunityQnAPostDTO;
@@ -24,12 +22,17 @@ public class CommunityRepositoryCustomImpl implements CommunityRepositoryCustom 
 
     private final JPAQueryFactory queryFactory;
 
+    private final QCommunity community = QCommunity.community;
+    private final QUser user = QUser.user;
+    private final QComment comment = QComment.comment;
+    private final QTag tag = QTag.tag; // QTag 추가
+
+    /**
+     * 멘토의 관심 태그 이름과 일치하는 QnA 게시글 중 최신순으로 N개 조회.
+     * CommunityQnAPostDTO의 communityTag 필드에는 입력된 interestTagName 값을 채워줍니다.
+     */
     @Override
     public List<CommunityQnAPostDTO> findRecentQnAPostsByInterest(String interestTag, int limit) {
-        QCommunity community = QCommunity.community;
-        QUser user = QUser.user;
-        QComment comment = QComment.comment;
-
         return queryFactory
                 .select(new QCommunityQnAPostDTO(
                         community.id,
@@ -38,15 +41,16 @@ public class CommunityRepositoryCustomImpl implements CommunityRepositoryCustom 
                         community.updatedAt.stringValue(), // ZonedDateTime → String
                         community.title,
                         community.content,
-                        community.communityTag,
+                        Expressions.constant(interestTag),
                         comment.id.count().intValue()     // 댓글 수 실시간 계산
                 ))
                 .from(community)
                 .join(community.user, user)
+                .leftJoin(community.tags, tag) // Community의 tags 컬렉션과 QTag 조인
                 .leftJoin(comment).on(comment.communityId.eq(community.id)) // 댓글 테이블과 연결
                 .where(
                         community.category.eq(CommunityCategory.QUESTION)
-                                .and(community.communityTag.eq(interestTag))
+                                .and(tag.name.eq(interestTag))
                 )
                 .groupBy(
                         community.id,
@@ -54,19 +58,19 @@ public class CommunityRepositoryCustomImpl implements CommunityRepositoryCustom 
                         user.profileImageUrl,
                         community.updatedAt,
                         community.title,
-                        community.content,
-                        community.communityTag
+                        community.content
                 )
                 .orderBy(community.updatedAt.desc())
                 .limit(limit)
                 .fetch();
     }
 
+    /**
+     * 멘토의 관심 태그 이름과 일치하는 QnA 게시글을 페이징하여 조회.
+     * CommunityQnAPostDTO의 communityTag 필드에는 입력된 interestTagName 값을 채워줍니다.
+     */
     @Override
     public Page<CommunityQnAPostDTO> findRecentQnAPostsByInterestPaged(String interestTag, Pageable pageable) {
-        QCommunity community = QCommunity.community;
-        QUser user = QUser.user;
-        QComment comment = QComment.comment;
 
         // 전체 게시글 조회 쿼리
         List<CommunityQnAPostDTO> content = queryFactory
@@ -77,15 +81,16 @@ public class CommunityRepositoryCustomImpl implements CommunityRepositoryCustom 
                         community.updatedAt.stringValue(),
                         community.title,
                         community.content,
-                        community.communityTag,
+                        Expressions.constant(interestTag),
                         comment.id.count().intValue()
                 ))
                 .from(community)
                 .join(community.user, user)
+                .leftJoin(community.tags, tag)
                 .leftJoin(comment).on(comment.communityId.eq(community.id))
                 .where(
                         community.category.eq(CommunityCategory.QUESTION),
-                        community.communityTag.eq(interestTag)
+                        tag.name.eq(interestTag)
                 )
                 .groupBy(
                         community.id,
@@ -93,8 +98,7 @@ public class CommunityRepositoryCustomImpl implements CommunityRepositoryCustom 
                         user.profileImageUrl,
                         community.updatedAt,
                         community.title,
-                        community.content,
-                        community.communityTag
+                        community.content
                 )
                 .orderBy(community.updatedAt.desc())
                 .offset(pageable.getOffset())
@@ -105,26 +109,37 @@ public class CommunityRepositoryCustomImpl implements CommunityRepositoryCustom 
         Long count = queryFactory
                 .select(community.count())
                 .from(community)
+                .leftJoin(community.tags, tag)
                 .where(
                         community.category.eq(CommunityCategory.QUESTION),
-                        community.communityTag.eq(interestTag)
+                        tag.name.eq(interestTag)
                 )
                 .fetchOne();
 
         return new PageImpl<>(content, pageable, count != null ? count : 0L);
     }
 
+    /**
+     * 다양한 조건으로 게시글을 고급 검색합니다.
+     * 태그 검색은 전달된 Tag 엔티티 객체를 포함하는 게시물을 찾습니다.
+     * 키워드 검색 시 게시물의 제목, 내용, 그리고 연결된 태그들의 이름도 검색 대상에 포함됩니다.
+     *
+     * @param keyword 검색 키워드
+     * @param nickname 작성자 닉네임
+     * @param category 게시글 카테고리
+     * @param userRole 사용자 역할
+     * @param tagEntity 검색할 특정 Tag 엔티티 (단일 태그). null일 경우 이 조건은 무시.
+     * @param pageable 페이징 정보
+     * @return 검색 결과 페이지
+     */
     @Override
     public Page<Community> advancedSearch(
             String keyword,
             String nickname,
             CommunityCategory category,
             String userRole,
-            String tag,
+            Tag tagEntity,
             Pageable pageable) {
-
-        QCommunity community = QCommunity.community;
-        QUser user = QUser.user;
 
         // 검색 조건 빌더
         BooleanBuilder builder = new BooleanBuilder();
@@ -134,7 +149,7 @@ public class CommunityRepositoryCustomImpl implements CommunityRepositoryCustom 
             builder.and(
                     community.title.containsIgnoreCase(keyword)
                             .or(community.content.containsIgnoreCase(keyword))
-                            .or(community.communityTag.containsIgnoreCase(keyword))
+                            .or(community.tags.any().name.containsIgnoreCase(keyword))
             );
         }
 
@@ -153,10 +168,11 @@ public class CommunityRepositoryCustomImpl implements CommunityRepositoryCustom 
             builder.and(user.role.stringValue().eq(userRole));
         }
 
-        // 태그로 검색
-        if (StringUtils.hasText(tag)) {
-            builder.and(community.communityTag.eq(tag));
+        // 특정 태그로 검색 (Tag 엔티티 객체로 검색)
+        if (tagEntity != null) {
+            builder.and(community.tags.contains(tagEntity)); // 수정: 해당 Tag 객체를 포함하는지 확인
         }
+
 
         // 게시글 조회 쿼리 생성
         List<Community> results = queryFactory
@@ -166,21 +182,17 @@ public class CommunityRepositoryCustomImpl implements CommunityRepositoryCustom 
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .orderBy(community.createdAt.desc()) // 기본 정렬
+                .distinct() // 태그 조인으로 인해 중복된 Community가 나올 수 있으므로 distinct 추가
                 .fetch();
 
         // 총 개수 조회 쿼리
-        long total = queryFactory
-                .select(community.count())
+        Long total = queryFactory
+                .select(community.id.countDistinct())
                 .from(community)
                 .join(community.user, user)
                 .where(builder)
-                .fetchOne() != null ? queryFactory
-                .select(community.count())
-                .from(community)
-                .join(community.user, user)
-                .where(builder)
-                .fetchOne() : 0L;
+                .fetchOne();
 
-        return new PageImpl<>(results, pageable, total);
+        return new PageImpl<>(results, pageable, total != null ? total : 0L);
     }
 }

--- a/src/main/java/com/team05/linkup/domain/community/infrastructure/TagRepository.java
+++ b/src/main/java/com/team05/linkup/domain/community/infrastructure/TagRepository.java
@@ -1,9 +1,15 @@
 package com.team05.linkup.domain.community.infrastructure;
 
 import com.team05.linkup.domain.community.domain.Tag;
+import com.team05.linkup.domain.community.dto.TagDTO;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -20,4 +26,15 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
      * @return Optional<Tag> 조회된 태그 (없으면 Optional.empty())
      */
     Optional<Tag> findByName(String name);
+
+    // 최근 N일 동안 사용된 태그를 빈도순으로 조회
+    // COUNT(c.id) 대신 COUNT(t.id) 또는 조인 테이블의 레코드를 세는 것이 더 정확할 수 있습니다.
+    @Query("SELECT new com.team05.linkup.domain.community.dto.TagDTO(t.name) " +
+            "FROM Community c JOIN c.tags t " +
+            "WHERE c.createdAt >= :sinceDate " +
+            "GROUP BY t.id, t.name " + // t.id 도 GROUP BY에 포함하는 것이 좋습니다.
+            "ORDER BY COUNT(c.id) DESC, t.name ASC")
+    List<TagDTO> findPopularTagsSince(@Param("sinceDate") ZonedDateTime sinceDate, Pageable pageable);
+
+    boolean existsByName(String name); // 태그 존재 여부 확인 메소드 (활용 가능)
 }

--- a/src/main/java/com/team05/linkup/domain/community/infrastructure/TagRepository.java
+++ b/src/main/java/com/team05/linkup/domain/community/infrastructure/TagRepository.java
@@ -1,0 +1,23 @@
+package com.team05.linkup.domain.community.infrastructure;
+
+import com.team05.linkup.domain.community.domain.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+/**
+ * Tag 엔티티에 대한 데이터 접근 계층(Repository)
+ * JpaRepository를 상속받아 기본적인 CRUD 기능을 제공하며,
+ * 필요한 커스텀 쿼리 메서드를 정의할 수 있습니다.
+ */
+@Repository
+public interface TagRepository extends JpaRepository<Tag, Long> {
+
+    /**
+     * 태그 이름으로 기존 태그를 조회합니다. (대소문자 구분)
+     * @param name 조회할 태그 이름
+     * @return Optional<Tag> 조회된 태그 (없으면 Optional.empty())
+     */
+    Optional<Tag> findByName(String name);
+}


### PR DESCRIPTION
## ✨ **PR 종류**

* [x] 기능 추가
* [x] 리팩토링
* [x] 문서 수정
* [ ] 버그 수정
* [ ] 기타

## 🛠️ **작업 요약**

이번 PR에서는 `BaseEntity`에 대한 Javadoc을 추가하여 문서화를 개선하고, 고유하고 재사용 가능한 태그를 관리하기 위한 `Tag` 엔티티를 추가했습니다. 

또한, `Community` 엔티티와 `Tag` 엔티티 간의 다대다 관계를 구현하고, 관련 DTO 및 Repository를 조정하여 다중 태그 기능을 지원하도록 리팩토링했습니다. (community 테이블 삭제 or ddl-auto: create-drop 설정)

더불어, 새로운 태그 구조에 맞춰 사용자 지정 쿼리를 업데이트하고, 태그 관리 로직을 서비스 레이어에 통합했으며, API 레이어에서 게시글 생성/수정 시 `providerId` 대신 `UserPrincipal`을 사용하도록 변경했습니다. 

마지막으로, 커뮤니티 인기 태그 조회 및 태그 필터링 기능을 추가했습니다.

## 📝 **작업 상세**

1.  **`docs: BaseEntity`에 대한 Javadoc 추가**
    * `com.team05.linkup.domain.baseEntity.BaseEntity` 클래스에 대한 Javadoc을 추가하여 해당 엔티티의 역할과 필드에 대한 설명을 제공했습니다. 이는 코드의 가독성을 높이고 유지보수를 용이하게 합니다.

2.  **`feat: 고유하고 재사용 가능한 태그를 관리하기 위한 태그 엔티티 추가`**
    * `com.team05.linkup.domain.community.domain.Tag` 엔티티를 새로 추가하여 커뮤니티 게시글에 태그를 연결하고 관리할 수 있도록 했습니다.
    * `name` 필드를 통해 태그의 고유성을 보장하고, `communities` 필드를 통해 해당 태그를 사용하는 게시글 목록을 관리합니다.
    * `@Table` 어노테이션을 사용하여 "tags" 테이블을 생성하고, `uk_tag_name` 유니크 제약 조건을 추가하여 태그 이름의 중복을 방지합니다.

3.  **`feat: 태그 엔티티와의 다대다 관계 구현`**
    * `com.team05.linkup.domain.community.domain.Community` 엔티티에서 기존의 `communityTag` 필드를 제거하고, `Tag` 엔티티와의 다대다 관계를 `@ManyToMany` 어노테이션과 `@JoinTable`을 사용하여 구현했습니다.
    * `community_tag_join` 테이블을 통해 `Community`와 `Tag` 엔티티 간의 관계를 관리하며, `cascade` 옵션을 통해 연관된 태그의 영속성 관리를 설정했습니다.
    * `update` 메소드를 수정하여 게시글 수정 시 태그 목록을 업데이트할 수 있도록 변경했습니다.

4.  **`feat: 태그 엔티티 작업을 위한 TagRepository 추가`**
    * `com.team05.linkup.domain.community.infrastructure.TagRepository` 인터페이스를 추가하여 `Tag` 엔티티에 대한 데이터 접근 기능을 제공합니다.
    * `findByName` 메소드를 통해 태그 이름으로 `Tag` 엔티티를 조회할 수 있도록 했습니다.

5.  **`refactor: 다중 태그 지원을 위한 DTO 조정`**
    * `com.team05.linkup.domain.community.dto.CommunityDto.Request` DTO에서 기존의 단일 태그 필드인 `communityTag`를 제거하고, 다중 태그를 처리하기 위한 `List<String> tags` 필드를 추가했습니다.
    * `com.team05.linkup.domain.community.dto.CommunityDto.Response` 및 `CommunityDto.DetailResponse`, `CommunityDto.CommunitySummaryResponse` DTO에서 태그 정보를 `List<String> tags` 형태로 반환하도록 수정했습니다.

6.  **`refactor: 새 태그 구조에 대한 사용자 지정 쿼리 업데이트`**
    * `com.team05.linkup.domain.community.infrastructure.CommunityRepositoryCustomImpl`에서 기존의 단일 태그 검색 관련 로직을 수정하여 다대다 관계를 기반으로 태그를 검색하도록 변경했습니다.
    * `findRecentQnAPostsByInterest` 메소드에서 `Tag` 엔티티와의 조인을 통해 관심 태그와 일치하는 게시글을 찾도록 수정했습니다.
    * `advancedSearch` 메소드에서 키워드 검색 시 게시글 제목, 내용뿐만 아니라 연결된 태그 이름에서도 검색이 이루어지도록 수정하고, 특정 `Tag` 엔티티를 기준으로 검색할 수 있도록 기능을 추가했습니다.

7.  **`feat: 다대다 태그 관리 로직 통합`**
    * `com.team05.linkup.domain.community.application.CommunityService`에 태그 목록(`List<String>`)을 받아 `Tag` 엔티티 Set으로 변환하는 `processTags` 메소드를 추가했습니다.
    * `createCommunity` 및 `updateCommunity` 메소드에서 `processTags`를 사용하여 요청으로부터 받은 태그 이름 목록을 `Tag` 엔티티 Set으로 변환하고, 이를 `Community` 엔티티에 연결하도록 수정했습니다.

8.  **`refactor: 게시글 생성/수정 - 서비스 레이어에 providerId -> userprincipal 인자 변경`**
    * `com.team05.linkup.domain.community.application.CommunityService`의 `createCommunity` 및 `updateCommunity` 메소드에서 사용자 식별자로 `providerId` 대신 `UserPrincipal` 객체를 받도록 변경하여 인증 정보를 직접 활용할 수 있도록 개선했습니다.
    * `com.team05.linkup.domain.community.api.CommunityController`의 관련 API 엔드포인트에서 서비스 메소드 호출 시 `UserPrincipal`을 전달하도록 수정했습니다.

9.  **`feat: 커뮤니티 인기 태그 조회 및 태그 필터링 기능 추가`**
    * `com.team05.linkup.domain.community.application.CommunityService`에 지정된 기간 동안 가장 많이 사용된 태그 목록을 조회하는 `findPopularTags` 메소드를 추가했습니다.
    * `com.team05.linkup.domain.community.infrastructure.TagRepository`에 인기 태그를 조회하는 `findPopularTagsSince` 쿼리 메소드를 추가했습니다.
    * `com.team05.linkup.domain.community.dto.TagDTO`를 추가하여 태그 이름을 담는 데 사용합니다.
    * `com.team05.linkup.domain.community.api.CommunityController`에 인기 태그를 조회하는 `/popular-tags` 엔드포인트를 추가했습니다.
    * `com.team05.linkup.domain.community.infrastructure.CommunityRepository`의 `findCommunitySummaries` 메소드를 수정하여 특정 태그 이름으로 게시글 목록을 필터링할 수 있도록 기능을 추가했습니다.
    * `com.team05.linkup.domain.community.api.CommunityController`의 `/list` 엔드포인트에서 `tag` 파라미터를 통해 태그별 게시글 목록 조회를 지원하도록 수정했습니다.

## ✅ **체크리스트**

* [ ] 코드 점검 완료
  - CommunityRepositoryCustomImpl 메서드 관련 코드 점검 필요
* [ ] 테스트 통과
  - CommunityRepositoryCustomImpl 메서드 관련 테스트 필요
  - 다중 태그 리스트 요청에 대해 저장, 응답 테스트 통과
![스크린샷 2025-05-08 113638](https://github.com/user-attachments/assets/26dccbc7-8279-41c9-9c17-c767751429b8)
* [x] 문서/주석 최신화 

## 📚 **기타**

* 다중 태그 기능을 통해 커뮤니티 게시글의 분류 및 검색이 더욱 용이해졌습니다.
* 인기 태그 조회 API를 통해 사용자들은 트렌드를 파악하고 관심 있는 주제를 쉽게 찾을 수 있습니다.
* 태그 필터링 기능을 통해 특정 태그가 포함된 게시글만 조회할 수 있어 사용자 경험이 향상될 것으로 기대됩니다.