### PR TITLE
[feat] 마이페이지 More Details 전체 API(me/type) 구조 통합 및 재능 목록 기능 개선

### DIFF
--- a/src/main/java/com/team05/linkup/domain/community/dto/CommunityTalentSummaryDTO.java
+++ b/src/main/java/com/team05/linkup/domain/community/dto/CommunityTalentSummaryDTO.java
@@ -15,8 +15,11 @@ import java.util.List;
 @AllArgsConstructor
 public class CommunityTalentSummaryDTO {
 
+    @Schema(description = "게시글 ID")
+    private String postId; // 게시글 클릭 시 해당 게시글 상세페이지로 이동하기 위한 필드 추가
+
     @Schema(description = "게시글 작성일 (UTC 기준)")
-    private ZonedDateTime createdAt; // 내가 등록한 재능 목록 각 항목 상단 작성일 추가
+    private ZonedDateTime createdAt;
 
     @Schema(description = "재능 게시글 제목")
     private String title;

--- a/src/main/java/com/team05/linkup/domain/community/dto/CommunityTalentSummaryDTO.java
+++ b/src/main/java/com/team05/linkup/domain/community/dto/CommunityTalentSummaryDTO.java
@@ -1,12 +1,31 @@
 package com.team05.linkup.domain.community.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+import java.time.ZonedDateTime;
+import java.util.List;
+
+/**
+ * 멘토 마이페이지 - 내가 등록한 재능 게시글 요약 정보 DTO
+ * - 미리보기 / 더보기 둘 다 이 구조 사용
+ */
 @Data
 @AllArgsConstructor
 public class CommunityTalentSummaryDTO {
+
+    @Schema(description = "게시글 작성일 (UTC 기준)")
+    private ZonedDateTime createdAt; // 내가 등록한 재능 목록 각 항목 상단 작성일 추가
+
+    @Schema(description = "재능 게시글 제목")
     private String title;
-    private String communityTagId;
+
+    @Schema(description = "커뮤니티 태그 이름 목록")
+    private List<String> tags; // 커뮤니티 태그 이름 리스트 (예: ["백엔드", "Java"])
+//    private String communityTagId;
+
+    @Schema(description = "게시글 내용 (최대 55자, 잘린 경우 ... 포함)")
     private String content;
+
 }

--- a/src/main/java/com/team05/linkup/domain/community/dto/CommunityTalentSummaryDTO.java
+++ b/src/main/java/com/team05/linkup/domain/community/dto/CommunityTalentSummaryDTO.java
@@ -9,25 +9,31 @@ import java.util.List;
 
 /**
  * 멘토 마이페이지 - 내가 등록한 재능 게시글 요약 정보 DTO
- * - 미리보기 / 더보기 둘 다 이 구조 사용
+ *
+ * <p>미리보기와 더보기 목록 모두 이 구조를 사용한다.</p>
+ * <p>게시글의 작성일, 제목, 커뮤니티 태그, 미리보기용 내용(최대 55자) 포함</p>
  */
 @Data
 @AllArgsConstructor
 public class CommunityTalentSummaryDTO {
 
-    @Schema(description = "게시글 ID")
-    private String postId; // 게시글 클릭 시 해당 게시글 상세페이지로 이동하기 위한 필드 추가
+    /** 게시글 고유 ID (상세페이지 이동용) */
+    @Schema(description = "게시글 ID (상세 페이지 이동용)")
+    private String postId;
 
+    /** 게시글 작성일 (UTC 기준) */
     @Schema(description = "게시글 작성일 (UTC 기준)")
     private ZonedDateTime createdAt;
 
+    /** 재능 게시글 제목 */
     @Schema(description = "재능 게시글 제목")
     private String title;
 
+    /** 커뮤니티 태그 이름 목록 (예: ["백엔드", "Java"]) */
     @Schema(description = "커뮤니티 태그 이름 목록")
-    private List<String> tags; // 커뮤니티 태그 이름 리스트 (예: ["백엔드", "Java"])
-//    private String communityTagId;
+    private List<String> tags;
 
+    /** 게시글 내용 (최대 55자, 잘린 경우 '...' 포함) */
     @Schema(description = "게시글 내용 (최대 55자, 잘린 경우 ... 포함)")
     private String content;
 

--- a/src/main/java/com/team05/linkup/domain/community/infrastructure/CommunityRepository.java
+++ b/src/main/java/com/team05/linkup/domain/community/infrastructure/CommunityRepository.java
@@ -83,9 +83,14 @@ public interface CommunityRepository extends JpaRepository<Community, String>, C
 
 
     /**
-     * 멘토 마이페이지 - 내가 등록한 재능 목록(최신 2개 조회) (미리보기용)
-     * - JOIN FETCH로 태그 함께 조회 (N+1 방지)
-     * -> LEFT JOIN FETCH - 태그가 없는 커뮤니티도 조회
+     * 멘토 마이페이지 - 내가 등록한 재능 목록 (미리보기 용, 최신 2개)
+     *
+     * <p>특정 닉네임의 유저가 작성한 커뮤니티 게시글 중, 카테고리가 'TALENT'인 글을 최신순으로 최대 2개까지 조회한다.</p>
+     * <p>태그는 JOIN FETCH를 통해 함께 로딩하며, 태그가 없는 게시글도 조회되도록 LEFT JOIN 사용.</p>
+     *
+     * @param nickname 닉네임 기준으로 게시글 필터링
+     * @param pageable PageRequest.of(0, 2) 형태의 페이징 정보
+     * @return 최신 재능 게시글 2개 (엔티티 리스트, 태그 포함)
      */
     @Query("""
         SELECT DISTINCT c FROM Community c
@@ -96,11 +101,15 @@ public interface CommunityRepository extends JpaRepository<Community, String>, C
     List<Community> findLatestTalentsByNickname(@Param("nickname") String nickname, Pageable pageable);
 
 
-    //
     /**
-     * 멘토 마이페이지 - 내가 등록한 재능 목록 더보기(전체 페이징 조회) (더보기용)
-     * - JOIN FETCH 사용하여 태그 즉시 로딩
-     * -> LEFT JOIN FETCH - 태그가 없는 커뮤니티도 조회
+     * 멘토 마이페이지 - 내가 등록한 재능 목록 (더보기 페이지용)
+     *
+     * <p>특정 닉네임의 유저가 작성한 'TALENT' 카테고리 커뮤니티 게시글 전체를 페이징 처리하여 조회한다.</p>
+     * <p>JOIN FETCH를 통해 태그를 함께 로딩하며, 태그가 없는 게시글도 조회된다.</p>
+     *
+     * @param nickname 닉네임 기준으로 게시글 필터링
+     * @param pageable 페이지 정보 (page, size 등)
+     * @return 재능 게시글 목록 (Page 타입, 태그 포함)
      */
     @Query("""
         SELECT DISTINCT c FROM Community c

--- a/src/main/java/com/team05/linkup/domain/community/infrastructure/CommunityRepository.java
+++ b/src/main/java/com/team05/linkup/domain/community/infrastructure/CommunityRepository.java
@@ -116,7 +116,7 @@ public interface CommunityRepository extends JpaRepository<Community, String>, C
     @Query(value = """
     SELECT 
         c.id,
-        c.updated_at,
+        c.created_at,
         c.category,
         c.title,
         CASE

--- a/src/main/java/com/team05/linkup/domain/community/infrastructure/CommunityRepository.java
+++ b/src/main/java/com/team05/linkup/domain/community/infrastructure/CommunityRepository.java
@@ -121,7 +121,14 @@ public interface CommunityRepository extends JpaRepository<Community, String>, C
 
 
 
-    // 공통 마이페이지 - 내가 작성한 커뮤니티 게시글
+    /**
+     * 마이페이지 - 내가 작성한 게시글 조회 (미리보기, 최신 N개)
+     * - TALENT 카테고리는 제외
+     *
+     * @param nickname 닉네임 기준
+     * @param limit 가져올 게시글 개수
+     * @return Object[] 리스트 (id, created_at, category, title, content, viewCount, likeCount, commentCount)
+     */
     @Query(value = """
     SELECT 
         c.id,
@@ -154,10 +161,12 @@ public interface CommunityRepository extends JpaRepository<Community, String>, C
     List<Object[]> findByCommunityPosts(@Param("nickname") String nickname, @Param("limit") int limit);
 
     /**
-     * 마이페이지 - 내가 작성한 커뮤니티 게시글 목록 조회 (페이징)
+     * 마이페이지 - 내가 작성한 게시글 조회 (더보기/페이징용)
+     * - TALENT 카테고리는 제외
      *
-     * @param nickname 유저 닉네임
-     * @param pageable 페이지 정보 (page, size 등)
+     * @param nickname 닉네임 기준
+     * @param pageable 페이지 정보
+     * @return Object[] Page (id, updated_at, category, title, content, viewCount, likeCount, commentCount)
      */
     @Query(value = """
     SELECT 

--- a/src/main/java/com/team05/linkup/domain/user/api/ProfileController.java
+++ b/src/main/java/com/team05/linkup/domain/user/api/ProfileController.java
@@ -66,7 +66,10 @@ public class ProfileController {
 
     @GetMapping("/{nickname}/activity")
     @Operation(summary = "나의 활동 내역 조회(멘토, 멘티 공통)", description = "멘토: 내가 등록한 재능 목록, 멘티: 내가 신청한 매칭, 내가 작성한 커뮤니티 게시글, 내가 작성한 댓글, 관심 목록 데이터를 조회합니다.")
-    public ResponseEntity<ApiResponse<ActivityResponseDTO>> getActivity(@PathVariable String nickname) {
+    public ResponseEntity<ApiResponse<ActivityResponseDTO>> getActivity(
+            @PathVariable String nickname,
+            @AuthenticationPrincipal UserPrincipal userPrincipal     // 🟢 로그인한 사용자 주입
+    ) {
         // 1. 사용자의 역할(멘토/멘티) 확인
         Optional<User> userOpt = userRepository.findByNickname(nickname);
         if (userOpt.isEmpty())
@@ -74,11 +77,26 @@ public class ProfileController {
                     .body(ApiResponse.error(ResponseCode.ENTITY_NOT_FOUND, "프로필을 찾을 수 없습니다."));
 
         User profile = userOpt.get();
-        logger.debug(profile.getRole());
+        logger.debug("🔍 요청 대상 닉네임의 역할: {}", profile.getRole());
+
+        // ✅ me 여부 판단: provider + providerId 기준으로 user 조회 → nickname 비교
+        boolean isMe = false;
+
+        if (userPrincipal != null) {
+            Optional<User> loginUser = userRepository.findByProviderAndProviderId(
+                    userPrincipal.provider(), userPrincipal.providerId()
+            );
+
+            isMe = loginUser
+                    .map(user -> nickname.equals(user.getNickname()))
+                    .orElse(false);
+        }
 
         // 공통 조회 항목 - Controller에서는 입출력과 역할 분기만 담당
+        // 공통 항목 DTO 생성 + me 설정
         ActivityResponseDTO.ActivityResponseDTOBuilder builder =
-                profileService.getCommonActivityDTO(nickname).toBuilder();
+                profileService.getCommonActivityDTO(nickname).toBuilder()
+                        .me(isMe); // ✅ 본인 여부 포함
 
         if (profile.getRole().equals(Role.ROLE_MENTOR)) {
             // 멘토의 경우, 커뮤니티 재능나눔 게시글 작성 내역 조회하여 반환

--- a/src/main/java/com/team05/linkup/domain/user/api/ProfileController.java
+++ b/src/main/java/com/team05/linkup/domain/user/api/ProfileController.java
@@ -159,28 +159,62 @@ public class ProfileController {
 
     private final InterestMoreDetailsService interestMoreDetailsService;
 
-    // 관심 목록 더보기 API
+//    // 관심 목록 더보기 API
+//    @GetMapping("/{nickname}/activity/more-details/interests")
+//    @Operation(summary = "나의 활동 내역 조회 more-details [관심 목록(북마크/좋아요)]", description = "북마크(bookmarked), 좋아요(liked), 전체(all) 옵션에 따라 관련 데이터를 자세히 조회합니다.")
+//    public ResponseEntity<ApiResponse<?>> getInterestMoreDetails(
+//            @PathVariable String nickname,
+//            @RequestParam("filter") String filter, // bookmarked | liked | all
+//            @RequestParam(value = "page", defaultValue = "0") int page,
+//            @RequestParam(value = "size", defaultValue = "10") int size
+//    ) {
+//        // 유효하지 않은 filter 처리
+//        if (!filter.equals("bookmarked") && !filter.equals("liked") && !filter.equals("all")) {
+//            return ResponseEntity
+//                    .status(HttpStatus.BAD_REQUEST)
+//                    .body(ApiResponse.error(ResponseCode.INVALID_INPUT_VALUE, "유효하지 않은 filter 파라미터입니다."));
+//        }
+//
+//        // 서비스 호출
+//        Page<?> result = interestMoreDetailsService.getInterestPosts(nickname, filter, page, size);
+//
+//        // 성공 응답 반환
+//        return ResponseEntity.ok(ApiResponse.success(result));
+//    }
+// 관심 목록 더보기 API
     @GetMapping("/{nickname}/activity/more-details/interests")
     @Operation(summary = "나의 활동 내역 조회 more-details [관심 목록(북마크/좋아요)]", description = "북마크(bookmarked), 좋아요(liked), 전체(all) 옵션에 따라 관련 데이터를 자세히 조회합니다.")
-    public ResponseEntity<ApiResponse<?>> getInterestMoreDetails(
+    public ResponseEntity<ApiResponse<ActivityMoreDetailsResponseDTO<InterestItemDTO>>> getInterestMoreDetails(
             @PathVariable String nickname,
             @RequestParam("filter") String filter, // bookmarked | liked | all
             @RequestParam(value = "page", defaultValue = "0") int page,
-            @RequestParam(value = "size", defaultValue = "10") int size
+            @RequestParam(value = "size", defaultValue = "10") int size,
+            @AuthenticationPrincipal UserPrincipal userPrincipal // 🔑 me 여부 계산용
     ) {
-        // 유효하지 않은 filter 처리
-        if (!filter.equals("bookmarked") && !filter.equals("liked") && !filter.equals("all")) {
+        // 1. filter 유효성 검사
+        if (!List.of("bookmarked", "liked", "all").contains(filter)) {
             return ResponseEntity
                     .status(HttpStatus.BAD_REQUEST)
                     .body(ApiResponse.error(ResponseCode.INVALID_INPUT_VALUE, "유효하지 않은 filter 파라미터입니다."));
         }
 
-        // 서비스 호출
-        Page<?> result = interestMoreDetailsService.getInterestPosts(nickname, filter, page, size);
+        // 2. 본인 여부 판단
+        boolean isMe = false;
+        if (userPrincipal != null) {
+            Optional<User> loginUserOpt = userRepository.findByProviderAndProviderId(
+                    userPrincipal.provider(), userPrincipal.providerId()
+            );
+            isMe = loginUserOpt.map(user -> user.getNickname().equals(nickname)).orElse(false);
+        }
 
-        // 성공 응답 반환
+        // 3. 래핑된 DTO 응답 호출
+        ActivityMoreDetailsResponseDTO<InterestItemDTO> result =
+                interestMoreDetailsService.getInterestPostsWrapped(nickname, filter, page, size, isMe);
+
+        // 4. 반환
         return ResponseEntity.ok(ApiResponse.success(result));
     }
+
 
     private final MatchingPageFacade matchingPageFacade;
 

--- a/src/main/java/com/team05/linkup/domain/user/api/ProfileController.java
+++ b/src/main/java/com/team05/linkup/domain/user/api/ProfileController.java
@@ -119,7 +119,8 @@ public class ProfileController {
             @PathVariable String nickname,
             @RequestParam("type") String type,
             @RequestParam(value = "page", defaultValue = "0") int page,
-            @RequestParam(value = "size", defaultValue = "10") int size   // size 파라미터 추가
+            @RequestParam(value = "size", defaultValue = "10") int size,
+            @AuthenticationPrincipal UserPrincipal userPrincipal // ✅ 여기서 닫기
     ) {
         return switch (type) {
             // 재능 목록 more-details
@@ -138,9 +139,9 @@ public class ProfileController {
 
             // 내가 쓴 댓글 more-details
             case "my-comments" -> {
-                Page<MyCommentResponseDTO> result =
-                        profileService.getMyCommentsPaged(nickname, page, size);
-                yield ResponseEntity.ok(ApiResponse.success(result));
+                ActivityMoreDetailsResponseDTO<MyCommentResponseDTO> dto =
+                        profileService.getMyCommentsMoreDetails(nickname, userPrincipal, page, size);
+                yield ResponseEntity.ok(ApiResponse.success(dto));
             }
 
             // 내가 신청한 매칭 more-details

--- a/src/main/java/com/team05/linkup/domain/user/api/ProfileController.java
+++ b/src/main/java/com/team05/linkup/domain/user/api/ProfileController.java
@@ -125,8 +125,8 @@ public class ProfileController {
         return switch (type) {
             // 재능 목록 more-details
             case "my-talents" -> {
-                Page<CommunityTalentSummaryDTO> result =
-                        mentorProfileService.getCommunityTalentsPaged(nickname, page, size);
+                ActivityMoreDetailsResponseDTO<CommunityTalentSummaryDTO> result =
+                        mentorProfileService.getMyTalentsMoreDetails(nickname, userPrincipal, page, size);
                 yield ResponseEntity.ok(ApiResponse.success(result));
             }
 

--- a/src/main/java/com/team05/linkup/domain/user/api/ProfileController.java
+++ b/src/main/java/com/team05/linkup/domain/user/api/ProfileController.java
@@ -132,9 +132,9 @@ public class ProfileController {
 
             // 내가 쓴 게시글 more-details
             case "my-posts" -> {
-                Page<MyPostResponseDTO> result =
-                        profileService.getMyPostsPaged(nickname, page, size);
-                yield ResponseEntity.ok(ApiResponse.success(result));
+                ActivityMoreDetailsResponseDTO<MyPostResponseDTO> dto =
+                        profileService.getMyPostsMoreDetails(nickname, userPrincipal, page, size);
+                yield ResponseEntity.ok(ApiResponse.success(dto));
             }
 
             // 내가 쓴 댓글 more-details

--- a/src/main/java/com/team05/linkup/domain/user/application/InterestMoreDetailsService.java
+++ b/src/main/java/com/team05/linkup/domain/user/application/InterestMoreDetailsService.java
@@ -1,6 +1,8 @@
 package com.team05.linkup.domain.user.application;
 
 import com.team05.linkup.domain.community.infrastructure.CommunityRepository;
+import com.team05.linkup.domain.user.dto.ActivityMoreDetailsResponseDTO;
+import com.team05.linkup.domain.user.dto.InterestItemDTO;
 import com.team05.linkup.domain.user.dto.MyBookmarkResponseDTO;
 import com.team05.linkup.domain.user.dto.MyLikeResponseDTO;
 import lombok.RequiredArgsConstructor;
@@ -94,4 +96,25 @@ public class InterestMoreDetailsService {
             default -> throw new IllegalArgumentException("유효하지 않은 filter 값입니다: " + filter);
         }
     }
+
+    public ActivityMoreDetailsResponseDTO<InterestItemDTO> getInterestPostsWrapped(
+            String nickname,
+            String filter,
+            int page,
+            int size,
+            boolean isMe
+    ) {
+        Page<?> resultPage = getInterestPosts(nickname, filter, page, size);
+
+        List<InterestItemDTO> content = resultPage.getContent().stream()
+                .map(item -> (InterestItemDTO) item)
+                .collect(Collectors.toList());
+
+        return ActivityMoreDetailsResponseDTO.<InterestItemDTO>builder()
+                .me(isMe)
+                .type(filter)
+                .content(content)
+                .build();
+    }
+
 }

--- a/src/main/java/com/team05/linkup/domain/user/application/MentorProfileService.java
+++ b/src/main/java/com/team05/linkup/domain/user/application/MentorProfileService.java
@@ -20,6 +20,11 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+/**
+ * 멘토 마이페이지 관련 서비스
+ *
+ * <p>재능 게시글 조회, 멘토링 통계 조회 등의 기능 제공</p>
+ */
 @Service
 @RequiredArgsConstructor
 public class MentorProfileService {
@@ -29,8 +34,13 @@ public class MentorProfileService {
 
     /**
      * 멘토 마이페이지 - 내가 등록한 재능 목록 (미리보기 2개)
-     * - 최신 등록된 TALENT 카테고리 게시글 2개를 조회
-     * - 커뮤니티 태그 리스트, 작성일, 제목, 내용(최대 55자) 포함
+     *
+     * <p>특정 멘토 닉네임 기준으로 최신 등록된 TALENT 카테고리 게시글을 2개 조회한다.</p>
+     * <p>각 게시글은 태그, 작성일, 제목, 내용(최대 55자 요약) 정보를 포함한다.</p>
+     *
+     * @param nickname 멘토의 닉네임
+     * @param limit 조회할 게시글 수 (일반적으로 2개)
+     * @return 재능 게시글 요약 정보 리스트
      */
     public List<CommunityTalentSummaryDTO> getCommunityTalents(String nickname, int limit) {
         // Pageable 생성
@@ -58,9 +68,15 @@ public class MentorProfileService {
     }
 
     /**
-     * 멘토 마이페이지 - 내가 등록한 재능 목록 (더보기 페이지)
-     * - page, size 기반으로 전체 TALENT 게시글을 페이징 조회
-     * - 각 게시글은 태그, 작성일, 제목, 내용(최대 55자) 포함
+     * 멘토 마이페이지 - 내가 등록한 재능 목록 (더보기 페이지용)
+     *
+     * <p>특정 멘토 닉네임 기준으로 TALENT 카테고리 게시글을 page, size 기반으로 페이징 조회한다.</p>
+     * <p>각 게시글은 태그, 작성일, 제목, 내용(최대 55자 요약) 정보를 포함한다.</p>
+     *
+     * @param nickname 멘토의 닉네임
+     * @param page 페이지 번호 (0부터 시작)
+     * @param size 페이지당 항목 수
+     * @return 페이징된 재능 게시글 요약 정보
      */
     public Page<CommunityTalentSummaryDTO> getCommunityTalentsPaged(String nickname, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);

--- a/src/main/java/com/team05/linkup/domain/user/application/MentorProfileService.java
+++ b/src/main/java/com/team05/linkup/domain/user/application/MentorProfileService.java
@@ -1,5 +1,6 @@
 package com.team05.linkup.domain.user.application;
 
+import com.team05.linkup.common.dto.UserPrincipal;
 import com.team05.linkup.domain.community.domain.Community;
 import com.team05.linkup.domain.community.domain.Tag;
 import com.team05.linkup.domain.community.dto.CommunityTalentSummaryDTO;
@@ -8,8 +9,11 @@ import com.team05.linkup.domain.enums.Interest;
 import com.team05.linkup.domain.mentoring.domain.MentorStatisticsView;
 import com.team05.linkup.domain.mentoring.infrastructure.MentorStatisticsRepository;
 import com.team05.linkup.domain.mentoring.infrastructure.MentoringRepository;
+import com.team05.linkup.domain.user.domain.User;
+import com.team05.linkup.domain.user.dto.ActivityMoreDetailsResponseDTO;
 import com.team05.linkup.domain.user.dto.InterestCountDTO;
 import com.team05.linkup.domain.user.dto.MentorStatsDTO;
+import com.team05.linkup.domain.user.infrastructure.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -17,6 +21,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -97,6 +102,38 @@ public class MentorProfileService {
             );
         });
     }
+
+    private final UserRepository userRepository;
+    public ActivityMoreDetailsResponseDTO<CommunityTalentSummaryDTO> getMyTalentsMoreDetails(
+            String nickname, UserPrincipal principal, int page, int size) {
+
+        Page<CommunityTalentSummaryDTO> resultPage = getCommunityTalentsPaged(nickname, page, size);
+
+        boolean isMe = false;
+        if (principal != null) {
+            Optional<User> loginUserOpt = userRepository.findByProviderAndProviderId(
+                    principal.provider(), principal.providerId()
+            );
+
+            loginUserOpt.ifPresent(user -> {
+                System.out.println("🔍 로그인 유저 nickname: " + user.getNickname());
+                System.out.println("📌 요청 경로의 nickname: " + nickname);
+            });
+
+            isMe = loginUserOpt.map(user -> user.getNickname().equals(nickname)).orElse(false);
+        } else {
+            System.out.println("⚠️ principal이 null임");
+        }
+
+        System.out.println("✅ me 여부 판단 결과: " + isMe);
+
+        return ActivityMoreDetailsResponseDTO.<CommunityTalentSummaryDTO>builder()
+                .me(isMe)
+                .type("my-talents")
+                .content(resultPage.getContent())
+                .build();
+    }
+
 
 
     // (리팩토링된) 멘토링 통계 조회 메서드 (DB View 기반)

--- a/src/main/java/com/team05/linkup/domain/user/application/MentorProfileService.java
+++ b/src/main/java/com/team05/linkup/domain/user/application/MentorProfileService.java
@@ -47,10 +47,11 @@ public class MentorProfileService {
                             : fullContent;
 
                     return new CommunityTalentSummaryDTO(
+                            community.getId(), // postId 추가
                             community.getCreatedAt(),
                             community.getTitle(),
                             community.getTags().stream().map(Tag::getName).toList(),
-                            preview // ✅ 자른 내용 적용
+                            preview // 자른 내용 적용
                     );
                 })
                 .collect(Collectors.toList());
@@ -72,6 +73,7 @@ public class MentorProfileService {
                     : fullContent;
 
             return new CommunityTalentSummaryDTO(
+                    community.getId(), // postId 추가
                     community.getCreatedAt(),
                     community.getTitle(),
                     community.getTags().stream().map(Tag::getName).toList(),

--- a/src/main/java/com/team05/linkup/domain/user/application/ProfileService.java
+++ b/src/main/java/com/team05/linkup/domain/user/application/ProfileService.java
@@ -137,6 +137,41 @@ public class ProfileService {
         ));
     }
 
+    /**
+     * [더보기] 내가 작성한 게시글 목록 응답 (me 여부 포함)
+     *
+     * @param nickname 조회 대상 사용자 닉네임
+     * @param principal 로그인 사용자 정보
+     * @param page 페이지 번호
+     * @param size 페이지 크기
+     * @return me + 게시글 리스트 래핑 DTO
+     */
+    public ActivityMoreDetailsResponseDTO<MyPostResponseDTO> getMyPostsMoreDetails(
+            String nickname, UserPrincipal principal, int page, int size) {
+
+        // 1. 게시글 목록 페이징 조회
+        Page<MyPostResponseDTO> result = getMyPostsPaged(nickname, page, size);
+
+        // 2. me 여부 판단
+        boolean isMe = false;
+        if (principal != null) {
+            Optional<User> loginUserOpt = userRepository.findByProviderAndProviderId(
+                    principal.provider(), principal.providerId()
+            );
+            isMe = loginUserOpt
+                    .map(user -> user.getNickname().equals(nickname))
+                    .orElse(false);
+        }
+
+        // 3. 응답 래핑
+        return ActivityMoreDetailsResponseDTO.<MyPostResponseDTO>builder()
+                .me(isMe)
+                .content(result.getContent())
+                .build();
+    }
+
+
+
 
     /**
      * 마이페이지 - 내가 작성한 댓글 목록 조회 (미리보기)

--- a/src/main/java/com/team05/linkup/domain/user/application/ProfileService.java
+++ b/src/main/java/com/team05/linkup/domain/user/application/ProfileService.java
@@ -87,24 +87,26 @@ public class ProfileService {
         return communityRepository.findUserIdByNickname(nickname);
     }
 
+    // 내가 작성한 게시글 (미리보기)
     public List<MyPostResponseDTO> getMyPosts(String nickname, int limit) {
         List<Object[]> rawResults = communityRepository.findByCommunityPosts(nickname, limit);
 
         return rawResults.stream()
                 .map(obj -> new MyPostResponseDTO(
                         (String) obj[0],                                      // id
-                        ((Timestamp) obj[1]).toInstant().atZone(ZoneOffset.UTC),              // updated_at
+                        ((Timestamp) obj[1]).toInstant().atZone(ZoneOffset.UTC),  // created_at
+                        // ((Timestamp) obj[2]).toInstant().atZone(ZoneOffset.UTC),  // updated_at
                         (String) obj[2],                                      // category
                         (String) obj[3],                                      // title
                         (String) obj[4],                                      // content
-                        ((Number) obj[5]).intValue(),                         // view_count (Long → int)
-                        ((Number) obj[6]).intValue(),                         // like_count (Long → int)
-                        ((Number) obj[7]).intValue()                          // comment_count (Long → int)
+                        ((Number) obj[5]).intValue(),                         // view_count
+                        ((Number) obj[6]).intValue(),                         // like_count
+                        ((Number) obj[7]).intValue()                          // comment_count
                 ))
                 .collect(Collectors.toList());
     }
 
-    // 내가 작성한 커뮤니티 게시글 - 페이징
+    // 내가 작성한 커뮤니티 게시글 - 페이징(더보기)
     public Page<MyPostResponseDTO> getMyPostsPaged(String nickname, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<Object[]> resultPage = communityRepository.findCommunityPostsWithPaging(nickname, pageable);

--- a/src/main/java/com/team05/linkup/domain/user/application/ProfileService.java
+++ b/src/main/java/com/team05/linkup/domain/user/application/ProfileService.java
@@ -22,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Timestamp;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -124,7 +125,13 @@ public class ProfileService {
     }
 
 
-    // 내가 작성한 댓글 조회
+    /**
+     * 마이페이지 - 내가 작성한 댓글 목록 조회 (미리보기)
+     *
+     * @param nickname 사용자 닉네임
+     * @param limit 조회할 개수 제한
+     * @return 댓글 미리보기 DTO 목록 (최대 55자 댓글 + 게시글 제목/카테고리 등 포함)
+     */
     public List<MyCommentResponseDTO> getMyComments(String nickname, int limit) {
         // userId 조회 (닉네임 기반 → ID 추출)
         String userId = getUserIdByNickname(nickname);
@@ -133,20 +140,38 @@ public class ProfileService {
         // DTO로 매핑
         return rows.stream()
                 .map(row -> {
-                        // 🛡️ null-safe 및 타입 캐스팅
-                        Timestamp updatedAt = (Timestamp) row[0];
-                        String description = (String) row[1];
-                        String commentContent = (String) row[2];
+                    // 컬럼 순서: post_id, category, created_at, post_title, description, comment_content
+                    // 🛡️ null-safe 및 타입 캐스팅
+                    String postId = (String) row[0];
+                    String category = (String) row[1];
+                    Timestamp createdAt = (Timestamp) row[2];
+                    ZonedDateTime createdDateTime = (createdAt != null)
+                            ? createdAt.toInstant().atZone(ZoneOffset.UTC)
+                            : null;
+//                    String description = (String) row[3];
+                    String postTitle = (String) row[3];
+                    String commentContent = (String) row[4];
 
-                        return new MyCommentResponseDTO(
-                                updatedAt != null ? updatedAt.toInstant().atZone(ZoneOffset.UTC) : null, // Timestamp가 null일 경우 NPE 방지
-                                description,
-                                commentContent
-                        );
+                    return new MyCommentResponseDTO(
+                            postId,
+                            category,
+                            createdDateTime,
+//                            description,
+                            postTitle,
+                            commentContent
+                    );
                 })
                 .collect(Collectors.toList());
     }
 
+    /**
+     * 마이페이지 - 내가 작성한 댓글 목록 조회 (더보기용 페이징)
+     *
+     * @param nickname 사용자 닉네임
+     * @param page 현재 페이지 번호
+     * @param size 페이지 당 항목 수
+     * @return 댓글 미리보기 DTO의 페이징 결과
+     */
     public Page<MyCommentResponseDTO> getMyCommentsPaged(String nickname, int page, int size) {
         // 1. 닉네임으로 사용자 ID 조회
         String userId = getUserIdByNickname(nickname);
@@ -157,13 +182,23 @@ public class ProfileService {
 
         // 4. Object[] → DTO 매핑
         return resultPage.map(row -> {
-            Timestamp updatedAt = (Timestamp) row[0];
-            String description = (String) row[1];
-            String commentContent = (String) row[2];
+            // 🛡️ null-safe 및 타입 캐스팅
+            String postId = (String) row[0];
+            String category = (String) row[1];
+            Timestamp createdAt = (Timestamp) row[2];
+            ZonedDateTime createdDateTime = (createdAt != null)
+                    ? createdAt.toInstant().atZone(ZoneOffset.UTC)
+                    : null;
+//            String description = (String) row[3];
+            String postTitle = (String) row[3];
+            String commentContent = (String) row[4];
 
             return new MyCommentResponseDTO(
-                    updatedAt != null ? updatedAt.toInstant().atZone(ZoneOffset.UTC) : null,
-                    description,
+                    postId,
+                    category,
+                    createdDateTime,
+//                    description,
+                    postTitle,
                     commentContent
             );
         });

--- a/src/main/java/com/team05/linkup/domain/user/application/ProfileService.java
+++ b/src/main/java/com/team05/linkup/domain/user/application/ProfileService.java
@@ -88,7 +88,13 @@ public class ProfileService {
         return communityRepository.findUserIdByNickname(nickname);
     }
 
-    // 내가 작성한 게시글 (미리보기)
+    /**
+     * 마이페이지 - 내가 작성한 커뮤니티 게시글 목록 조회 (미리보기용, 상위 N개)
+     *
+     * @param nickname 닉네임 (user.nickname)
+     * @param limit 가져올 게시글 개수 (최신순 제한)
+     * @return 게시글 요약 정보 리스트
+     */
     public List<MyPostResponseDTO> getMyPosts(String nickname, int limit) {
         List<Object[]> rawResults = communityRepository.findByCommunityPosts(nickname, limit);
 
@@ -107,7 +113,14 @@ public class ProfileService {
                 .collect(Collectors.toList());
     }
 
-    // 내가 작성한 커뮤니티 게시글 - 페이징(더보기)
+    /**
+     * 마이페이지 - 내가 작성한 커뮤니티 게시글 목록 조회 (페이징: 더보기 탭용)
+     *
+     * @param nickname 닉네임 (user.nickname)
+     * @param page 페이지 번호 (0부터 시작)
+     * @param size 페이지당 항목 수
+     * @return 게시글 요약 정보 페이징 결과
+     */
     public Page<MyPostResponseDTO> getMyPostsPaged(String nickname, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<Object[]> resultPage = communityRepository.findCommunityPostsWithPaging(nickname, pageable);

--- a/src/main/java/com/team05/linkup/domain/user/application/ProfileService.java
+++ b/src/main/java/com/team05/linkup/domain/user/application/ProfileService.java
@@ -217,6 +217,40 @@ public class ProfileService {
         });
     }
 
+    /**
+     * [더보기] 내가 작성한 댓글 목록 응답 (me 여부 포함)
+     *
+     * @param nickname 조회 대상 사용자 닉네임
+     * @param principal 로그인 사용자 정보
+     * @param page 페이지 번호
+     * @param size 페이지 크기
+     * @return me + 댓글 리스트 래핑 DTO
+     */
+    public ActivityMoreDetailsResponseDTO<MyCommentResponseDTO> getMyCommentsMoreDetails(
+            String nickname, UserPrincipal principal, int page, int size) {
+
+        // 1. 댓글 목록 페이징 조회
+        Page<MyCommentResponseDTO> result = getMyCommentsPaged(nickname, page, size);
+
+        // 2. me 여부 판단
+        boolean isMe = false;
+        if (principal != null) {
+            Optional<User> loginUserOpt = userRepository.findByProviderAndProviderId(
+                    principal.provider(), principal.providerId()
+            );
+            isMe = loginUserOpt
+                    .map(user -> user.getNickname().equals(nickname))
+                    .orElse(false);
+        }
+
+        // 3. 응답 래핑
+        return ActivityMoreDetailsResponseDTO.<MyCommentResponseDTO>builder()
+                .me(isMe)
+                .content(result.getContent()) // Page → List
+                .build();
+    }
+
+
 
     // 내가 북마크한 게시글 조회
      public List<MyBookmarkResponseDTO> getMyBookmarks(String nickname, int limit) {

--- a/src/main/java/com/team05/linkup/domain/user/dto/ActivityMoreDetailsResponseDTO.java
+++ b/src/main/java/com/team05/linkup/domain/user/dto/ActivityMoreDetailsResponseDTO.java
@@ -10,6 +10,7 @@ import java.util.List;
 /**
  * [마이페이지] 더보기 API 응답용 공통 DTO
  * - me: 현재 로그인 사용자인지 여부
+ * - type: 필터 종류 ("bookmarked", "liked", "all") → 관심 목록에서만 사용
  * - content: 실제 데이터 목록 (댓글, 게시글 등)
  */
 @Getter
@@ -19,6 +20,9 @@ public class ActivityMoreDetailsResponseDTO<T> {
 
     @Schema(description = "본인 여부 (true: 내 활동, false: 타인 활동)")
     private boolean me;
+
+    @Schema(description = "관심 목록 타입 (bookmarked | liked | all)")
+    private String type;
 
     @Schema(description = "더보기 리스트 응답 데이터")
     private List<T> content;

--- a/src/main/java/com/team05/linkup/domain/user/dto/ActivityMoreDetailsResponseDTO.java
+++ b/src/main/java/com/team05/linkup/domain/user/dto/ActivityMoreDetailsResponseDTO.java
@@ -1,0 +1,25 @@
+package com.team05.linkup.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * [마이페이지] 더보기 API 응답용 공통 DTO
+ * - me: 현재 로그인 사용자인지 여부
+ * - content: 실제 데이터 목록 (댓글, 게시글 등)
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+public class ActivityMoreDetailsResponseDTO<T> {
+
+    @Schema(description = "본인 여부 (true: 내 활동, false: 타인 활동)")
+    private boolean me;
+
+    @Schema(description = "더보기 리스트 응답 데이터")
+    private List<T> content;
+}

--- a/src/main/java/com/team05/linkup/domain/user/dto/ActivityResponseDTO.java
+++ b/src/main/java/com/team05/linkup/domain/user/dto/ActivityResponseDTO.java
@@ -2,23 +2,40 @@ package com.team05.linkup.domain.user.dto;
 
 import com.team05.linkup.domain.community.dto.CommunityTalentSummaryDTO;
 import com.team05.linkup.domain.mentoring.dto.MatchedMentorProfileDto;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
 
+/**
+ * 마이페이지 - 활동 내역 응답 DTO (멘토/멘티 공통)
+ */
 @Getter
 @Builder(toBuilder = true)
 public class ActivityResponseDTO {
+
+    @Schema(description = "프로필 닉네임 (본인 여부 판별용)")
     private String nickname;    // 프론트에서 "내 활동 내역" vs "OOO님의 활동 내역" 판단용
+
+    @Schema(description = "내가 작성한 커뮤니티 게시글 목록")
     private List<MyPostResponseDTO> posts;
+
+    @Schema(description = "내가 작성한 댓글 목록")
     private List<MyCommentResponseDTO> comments;
+
+    @Schema(description = "북마크한 게시글 목록")
     private List<MyBookmarkResponseDTO> bookmarks;
+
+    @Schema(description = "좋아요 누른 게시글 목록")
     private List<MyLikeResponseDTO> likes;
 
+
     // 멘토 전용
+    @Schema(description = "멘토 전용 - 내가 등록한 재능 게시글 목록")
     private List<CommunityTalentSummaryDTO> talents;
 
     // 멘티 전용
+    @Schema(description = "멘티 전용 - 내가 신청한 멘토 목록")
     private List<MatchedMentorProfileDto> matches;
 }

--- a/src/main/java/com/team05/linkup/domain/user/dto/ActivityResponseDTO.java
+++ b/src/main/java/com/team05/linkup/domain/user/dto/ActivityResponseDTO.java
@@ -15,6 +15,9 @@ import java.util.List;
 @Builder(toBuilder = true)
 public class ActivityResponseDTO {
 
+    @Schema(description = "현재 로그인한 사용자인지 여부")
+    private boolean me; // 🟢 [신규] 본인 여부 플래그
+
     @Schema(description = "프로필 닉네임 (본인 여부 판별용)")
     private String nickname;    // 프론트에서 "내 활동 내역" vs "OOO님의 활동 내역" 판단용
 

--- a/src/main/java/com/team05/linkup/domain/user/dto/MyCommentResponseDTO.java
+++ b/src/main/java/com/team05/linkup/domain/user/dto/MyCommentResponseDTO.java
@@ -1,21 +1,23 @@
 package com.team05.linkup.domain.user.dto;
 
+import com.team05.linkup.domain.community.domain.CommunityCategory;
+
 import java.time.ZonedDateTime;
 
 /**
  * [마이페이지] 내가 작성한 댓글 응답 DTO
- * - 게시글 ID, 카테고리, 제목, 작성일, 댓글 내용 포함
+ * <br>
+ * - 게시글 ID, 카테고리, 제목, 작성일, 댓글 내용 포함<br>
  * - 프론트에서 댓글 목록 출력 및 링크 연결에 사용
  */
 public class MyCommentResponseDTO {
     private String postId;  // 게시글 ID (프론트에서 링크 이동에 사용)
 
     private String category; // 게시글 카테고리 (자유게시판, Q&A 등)
+    private String categoryDisplayName;  // ✅ 한글 표시용 (예: 자유게시판)
 
-//    private ZonedDateTime updatedAt;
     private ZonedDateTime createdAt;     // 댓글 작성일 (UTC 기준)
 
-//    private String description;      // 예: "ㅇㅇㅇㅇㅇ" 게시글에 댓글
     private String postTitle;    // 게시글 제목
 
     private String commentContent;
@@ -23,17 +25,14 @@ public class MyCommentResponseDTO {
     public MyCommentResponseDTO(
             String postId,
             String category,
-            /*ZonedDateTime updatedAt, */
             ZonedDateTime createdAt,
-//            String description,
             String postTitle,
             String commentContent
     ) {
         this.postId = postId;
         this.category = category;
-//        this.updatedAt = updatedAt;
+        this.categoryDisplayName = CommunityCategory.valueOf(category).getDisplayName(); // ✅ 변환 추가
         this.createdAt = createdAt;
-//        this.description = description;
         this.postTitle = postTitle;
         this.commentContent = commentContent;
     }
@@ -46,13 +45,15 @@ public class MyCommentResponseDTO {
         return category;
     }
 
-//    public ZonedDateTime getUpdatedAt() {return updatedAt;}
+    public String getCategoryDisplayName() {
+        return categoryDisplayName;
+    }
+
     public ZonedDateTime getCreatedAt() {
         return createdAt;
     }
 
 
-//    public String getDescription() {return description;}
     public String getPostTitle() {  // 아래 getCommentContent()와 동일하게 JSON 응답용
         return postTitle;
     }

--- a/src/main/java/com/team05/linkup/domain/user/dto/MyCommentResponseDTO.java
+++ b/src/main/java/com/team05/linkup/domain/user/dto/MyCommentResponseDTO.java
@@ -14,13 +14,15 @@ public class MyCommentResponseDTO {
     private String postId;  // 게시글 ID (프론트에서 링크 이동에 사용)
 
     private String category; // 게시글 카테고리 (자유게시판, Q&A 등)
-    private String categoryDisplayName;  // ✅ 한글 표시용 (예: 자유게시판)
+    private String categoryDisplayName;  // 한글 표시용 (예: 자유게시판)
 
     private ZonedDateTime createdAt;     // 댓글 작성일 (UTC 기준)
 
     private String postTitle;    // 게시글 제목
 
     private String commentContent;
+
+    private String postUrl; // ✅ 새로 추가된 필드
 
     public MyCommentResponseDTO(
             String postId,
@@ -31,10 +33,13 @@ public class MyCommentResponseDTO {
     ) {
         this.postId = postId;
         this.category = category;
-        this.categoryDisplayName = CommunityCategory.valueOf(category).getDisplayName(); // ✅ 변환 추가
+        this.categoryDisplayName = CommunityCategory.valueOf(category).getDisplayName(); // 변환 추가
         this.createdAt = createdAt;
         this.postTitle = postTitle;
         this.commentContent = commentContent;
+
+        // ✅ 게시글 상세 이동 URL 자동 생성
+        this.postUrl = "/community/detail/" + postId;
     }
 
     public String getPostId() {
@@ -62,5 +67,10 @@ public class MyCommentResponseDTO {
     // 삭제 시 댓글 내용이 응답에 포함되지 않으므로 유지 필수
     public String getCommentContent() {
         return commentContent;
+    }
+
+    // ✅ 새로 추가된 getter
+    public String getPostUrl() {
+        return postUrl;
     }
 }

--- a/src/main/java/com/team05/linkup/domain/user/dto/MyCommentResponseDTO.java
+++ b/src/main/java/com/team05/linkup/domain/user/dto/MyCommentResponseDTO.java
@@ -2,23 +2,59 @@ package com.team05.linkup.domain.user.dto;
 
 import java.time.ZonedDateTime;
 
+/**
+ * [마이페이지] 내가 작성한 댓글 응답 DTO
+ * - 게시글 ID, 카테고리, 제목, 작성일, 댓글 내용 포함
+ * - 프론트에서 댓글 목록 출력 및 링크 연결에 사용
+ */
 public class MyCommentResponseDTO {
-    private ZonedDateTime updatedAt;
-    private String description;      // 예: "게시글 제목에 댓글"
+    private String postId;  // 게시글 ID (프론트에서 링크 이동에 사용)
+
+    private String category; // 게시글 카테고리 (자유게시판, Q&A 등)
+
+//    private ZonedDateTime updatedAt;
+    private ZonedDateTime createdAt;     // 댓글 작성일 (UTC 기준)
+
+//    private String description;      // 예: "ㅇㅇㅇㅇㅇ" 게시글에 댓글
+    private String postTitle;    // 게시글 제목
+
     private String commentContent;
 
-    public MyCommentResponseDTO(ZonedDateTime updatedAt, String description, String commentContent) {
-        this.updatedAt = updatedAt;
-        this.description = description;
+    public MyCommentResponseDTO(
+            String postId,
+            String category,
+            /*ZonedDateTime updatedAt, */
+            ZonedDateTime createdAt,
+//            String description,
+            String postTitle,
+            String commentContent
+    ) {
+        this.postId = postId;
+        this.category = category;
+//        this.updatedAt = updatedAt;
+        this.createdAt = createdAt;
+//        this.description = description;
+        this.postTitle = postTitle;
         this.commentContent = commentContent;
     }
 
-    public ZonedDateTime getUpdatedAt() {
-        return updatedAt;
+    public String getPostId() {
+        return postId;
     }
 
-    public String getDescription() {
-        return description;
+    public String getCategory() {
+        return category;
+    }
+
+//    public ZonedDateTime getUpdatedAt() {return updatedAt;}
+    public ZonedDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+
+//    public String getDescription() {return description;}
+    public String getPostTitle() {  // 아래 getCommentContent()와 동일하게 JSON 응답용
+        return postTitle;
     }
 
     // 이 getter는 명시적으로 호출되지 않아도 JSON 변환 시 사용됨 (e.g., @RestController 응답)

--- a/src/main/java/com/team05/linkup/domain/user/dto/MyPostResponseDTO.java
+++ b/src/main/java/com/team05/linkup/domain/user/dto/MyPostResponseDTO.java
@@ -6,17 +6,45 @@ import lombok.Getter;
 
 import java.time.ZonedDateTime;
 
+/**
+ * 마이페이지 - 내가 작성한 커뮤니티 게시글 응답 DTO
+ * <p>
+ * 커뮤니티에서 사용자가 작성한 게시글 정보를 요약해서 응답하는 데 사용됩니다.
+ * <br>
+ * 게시글 ID, 작성일, 카테고리(영문/한글), 제목, 내용 요약, 조회수, 좋아요 수, 댓글 수를 포함합니다.
+ * </p>
+ */
 @Getter
 public class MyPostResponseDTO {
+    /**
+     * 게시글 ID
+     * <p>응답 JSON에서는 postId로 반환됨</p>
+     */
     @JsonProperty("postId") // ✅ 응답에서 postId로 직렬화
     private String id;
+
+    /** 게시글 작성일 (UTC 기준) */
     private ZonedDateTime createdAt;
+
+    /** 게시글 카테고리 (영문 ENUM 값, 예: QUESTION, INFO) */
     private String category;
-    private String categoryDisplayName; // ✅ 프론트 출력용
+
+    /** 게시글 카테고리의 한글 이름 (예: 질문/답변, 정보공유) */
+    private String categoryDisplayName; // 프론트 출력용
+
+    /** 게시글 제목 */
     private String title;
+
+    /** 게시글 요약 내용 (최대 55자 + "...") */
     private String content;
+
+    /** 게시글 조회 수 */
     private int viewCount;
+
+    /** 게시글 좋아요 수 */
     private int likeCount;
+
+    /** 게시글 댓글 수 */
     private int commentCount;
 
     public MyPostResponseDTO(
@@ -41,7 +69,11 @@ public class MyPostResponseDTO {
     }
 
     /**
-     * 🔹 Enum 이름을 출력용 displayName으로 변환하는 유틸 메서드
+     * 주어진 카테고리 ENUM 이름(String)을 displayName(한글)으로 변환합니다.
+     * <p>잘못된 값이 들어올 경우 그대로 반환합니다.</p>
+     *
+     * @param categoryName ENUM 값 (예: QUESTION)
+     * @return 한글 displayName (예: 질문/답변)
      */
     private String convertToDisplayName(String categoryName) {
         try {

--- a/src/main/java/com/team05/linkup/domain/user/dto/MyPostResponseDTO.java
+++ b/src/main/java/com/team05/linkup/domain/user/dto/MyPostResponseDTO.java
@@ -1,5 +1,6 @@
 package com.team05.linkup.domain.user.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.team05.linkup.domain.community.domain.CommunityCategory;
 import lombok.Getter;
 
@@ -7,6 +8,7 @@ import java.time.ZonedDateTime;
 
 @Getter
 public class MyPostResponseDTO {
+    @JsonProperty("postId") // ✅ 응답에서 postId로 직렬화
     private String id;
     private ZonedDateTime createdAt;
     private String category;

--- a/src/main/java/com/team05/linkup/domain/user/dto/MyPostResponseDTO.java
+++ b/src/main/java/com/team05/linkup/domain/user/dto/MyPostResponseDTO.java
@@ -1,5 +1,6 @@
 package com.team05.linkup.domain.user.dto;
 
+import com.team05.linkup.domain.community.domain.CommunityCategory;
 import lombok.Getter;
 
 import java.time.ZonedDateTime;
@@ -7,27 +8,47 @@ import java.time.ZonedDateTime;
 @Getter
 public class MyPostResponseDTO {
     private String id;
-    private ZonedDateTime createdAt;    // 작성일
-//    private ZonedDateTime updatedAt;  // 수정일
+    private ZonedDateTime createdAt;
     private String category;
+    private String categoryDisplayName; // ✅ 프론트 출력용
     private String title;
     private String content;
     private int viewCount;
     private int likeCount;
     private int commentCount;
 
-    public MyPostResponseDTO(String id, ZonedDateTime createdAt, /*ZonedDateTime updatedAt,*/ String category, String title, String content,
-                             int viewCount, int likeCount, int commentCount) {
+    public MyPostResponseDTO(
+            String id,
+            ZonedDateTime createdAt,
+            String category,
+            String title,
+            String content,
+            int viewCount,
+            int likeCount,
+            int commentCount
+    ) {
         this.id = id;
         this.createdAt = createdAt;
-//        this.updatedAt = updatedAt;
         this.category = category;
+        this.categoryDisplayName = convertToDisplayName(category); // ✅ 변환 처리
         this.title = title;
         this.content = content;
         this.viewCount = viewCount;
         this.likeCount = likeCount;
         this.commentCount = commentCount;
     }
+
+    /**
+     * 🔹 Enum 이름을 출력용 displayName으로 변환하는 유틸 메서드
+     */
+    private String convertToDisplayName(String categoryName) {
+        try {
+            return CommunityCategory.valueOf(categoryName).getDisplayName();
+        } catch (IllegalArgumentException e) {
+            return categoryName; // 혹시 모를 잘못된 값 대비 fallback
+        }
+    }
+
 
 }
 

--- a/src/main/java/com/team05/linkup/domain/user/dto/MyPostResponseDTO.java
+++ b/src/main/java/com/team05/linkup/domain/user/dto/MyPostResponseDTO.java
@@ -7,7 +7,8 @@ import java.time.ZonedDateTime;
 @Getter
 public class MyPostResponseDTO {
     private String id;
-    private ZonedDateTime updatedAt;
+    private ZonedDateTime createdAt;    // 작성일
+//    private ZonedDateTime updatedAt;  // 수정일
     private String category;
     private String title;
     private String content;
@@ -15,10 +16,11 @@ public class MyPostResponseDTO {
     private int likeCount;
     private int commentCount;
 
-    public MyPostResponseDTO(String id, ZonedDateTime updatedAt, String category, String title, String content,
+    public MyPostResponseDTO(String id, ZonedDateTime createdAt, /*ZonedDateTime updatedAt,*/ String category, String title, String content,
                              int viewCount, int likeCount, int commentCount) {
         this.id = id;
-        this.updatedAt = updatedAt;
+        this.createdAt = createdAt;
+//        this.updatedAt = updatedAt;
         this.category = category;
         this.title = title;
         this.content = content;


### PR DESCRIPTION
## ✨ PR 종류

- [x] 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 🛠️ 작업 요약

- 마이페이지 more-details API 전반에 me, type, content 구조 적용
- 게시글/댓글/재능/관심목록 API 통합 구조 정리 및 UI 연동 필드 추가
- 기존 응답 구조 개선 및 JavaDoc 문서 추가


## 📝 작업 상세

- 공통 응답 구조 개선
    - ActivityMoreDetailsResponseDTO<T> 공통 래퍼 DTO 생성
    → 모든 more-details 응답에 me, type, content 포함하도록 변경
    - 기존에 Page<T>로 반환되던 응답 → 래핑 구조로 통일 (프론트 구분 로직 개선 목적)

- 본인 여부(me) 판단 로직 추가
    - UserPrincipal을 활용한 me 여부 판별 로직 도입 (nickname 비교)
    - ProfileController 내부 모든 more-details API에 적용 완료

- 관심 목록 more-details API 리팩토링
    - /v1/users/{nickname}/activity/more-details/interests
    - filter=bookmarked|liked|all 적용 시 분기 처리
    - 북마크 / 좋아요 DTO 통합 래핑 구조 적용
    - DTO 내부에 type, updatedAt, title, content 필드 명확화

- 게시글 / 댓글 more-details 개선
    - 게시글 DTO에 postId 필드 추가 (상세페이지 이동용)
    - 댓글 DTO에 postUri 필드 추가 (상세페이지 링크용)
    - category → categoryDisplayName 필드 추가 및 한글 변환 적용

-  재능 목록 more-details 개선
    - 기존 Page<CommunityTalentSummaryDTO> → ActivityMoreDetailsResponseDTO 래핑 적용
    - 서비스 메서드 getMyTalentsMoreDetails(...) 도입
    - Controller 단에서 nickname, principal 모두 활용해 me 판단

- JavaDoc 주석 추가
    - 관련 DTO, Service, Repository에 JavaDoc 일부 적용
    (가독성 향상 및 유지보수 목적)

## ✅ 체크리스트

- [x] 코드 점검 완료
- [x] 테스트 통과
- [x] 문서/주석 최신화

## 📚 기타

- 프론트 UI에서 더보기 버튼 클릭 시 me 및 type 기반으로 콘텐츠 구분 가능
- postId, postUri, categoryDisplayName 등 UI 연동 필드 정비
- 이후 진행될 관심목록 및 마이페이지 레이아웃 개선을 위한 기반 작업 완료
- (프로필 설정 부분도 다시 한 번 점검해보고 혹시 수정할 부분 있으면 최대한 빠르게 리팩토링해서 올려두겠습니다)