### PR TITLE
[feat] Supabase 이미지 업로드 안정화 & `images.object_path` 마이그레이션

### DIFF
--- a/sql/images_object_path_canonical.sql
+++ b/sql/images_object_path_canonical.sql
@@ -1,0 +1,20 @@
+DROP PROCEDURE IF EXISTS drop_column_if_exists;
+DELIMITER //
+CREATE PROCEDURE drop_column_if_exists()
+BEGIN
+    IF EXISTS (
+        SELECT * FROM information_schema.columns 
+        WHERE table_schema = DATABASE()
+        AND table_name = 'images' 
+        AND column_name = 'object_path'
+    ) THEN
+        ALTER TABLE images DROP COLUMN object_path;
+    END IF;
+END //
+DELIMITER ;
+
+CALL drop_column_if_exists();
+DROP PROCEDURE IF EXISTS drop_column_if_exists;
+
+-- B. image_url → object_path 로 이름 변경 + 길이 확대
+ALTER TABLE images CHANGE image_url object_path VARCHAR(512) NOT NULL;

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -69,7 +69,7 @@ CREATE TABLE images (
     id VARCHAR(36) PRIMARY KEY,
     user_id VARCHAR(36),
     community_id VARCHAR(36),
-    image_url VARCHAR(255) NOT NULL ,
+    object_path VARCHAR(512) NOT NULL,   -- ← image_url → object_path
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 

--- a/src/main/generated/com/team05/linkup/domain/community/domain/QImage.java
+++ b/src/main/generated/com/team05/linkup/domain/community/domain/QImage.java
@@ -31,7 +31,7 @@ public class QImage extends EntityPathBase<Image> {
 
     public final StringPath id = createString("id");
 
-    public final StringPath imageUrl = createString("imageUrl");
+    public final StringPath objectPath = createString("objectPath");
 
     //inherited
     public final DateTimePath<java.time.ZonedDateTime> updatedAt = _super.updatedAt;

--- a/src/main/java/com/team05/linkup/common/config/SupabaseConfig.java
+++ b/src/main/java/com/team05/linkup/common/config/SupabaseConfig.java
@@ -1,15 +1,27 @@
 package com.team05.linkup.common.config;
 
-import io.supabase.StorageClient;                // ✅ 추가
-import org.springframework.beans.factory.annotation.Value; // ✅ 추가
+import io.supabase.StorageClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+
 @Configuration
+@RequiredArgsConstructor
 public class SupabaseConfig {
+
+    @Value("${supabase.storage-url}")
+    private String storageUrl;      // ← application.yml 에서 주입
+
+    @Value("${supabase.service-key}")
+    private String serviceKey;      // ← 반드시 service_role 키
+
+    /** StorageClient Bean */
     @Bean
-    public StorageClient storageClient(@Value("${supabase.url}") String url,
-                                       @Value("${supabase.service-key}") String key) {
-        return new StorageClient(key, url);          // storage-java SDK
+    public StorageClient storageClient() {
+        // ★ URL 끝에 / 없으면 추가
+        String normalized = storageUrl.endsWith("/") ? storageUrl : storageUrl + "/";
+        return new StorageClient(serviceKey, normalized);   // (apiKey, url)
     }
 }

--- a/src/main/java/com/team05/linkup/domain/community/application/CommunityService.java
+++ b/src/main/java/com/team05/linkup/domain/community/application/CommunityService.java
@@ -102,18 +102,24 @@ public class CommunityService {
      * @param pageable 페이징 및 정렬 정보 (페이지 번호, 페이지 크기, 정렬 기준). Spring Data Web Support에 의해 Controller에서 생성됩니다.
      * @return 조건에 맞는 게시글 요약 정보({@link CommunitySummaryResponseDTO})를 담고 있는 {@link Page} 객체.
      * 결과가 없을 경우 빈 Page 객체가 반환됩니다.
-     * @see CommunityRepository#findCommunitySummaries(CommunityCategory, Pageable)
+     * @see CommunityRepository #findCommunitySummaries(CommunityCategory, Pageable)
      */
     public Page<CommunitySummaryResponseDTO> findCommunities(CommunityCategory category, String tagName, Pageable pageable) {
-        String trimmedTagName = null;
-        if (StringUtils.hasText(tagName)) {
-            trimmedTagName = tagName.trim();
-        }
+        String trimmedTagName = StringUtils.hasText(tagName) ? tagName.trim() : null;
+
         return communityRepository.findCommunitySummaries(
                 category,
                 trimmedTagName,
-                pageable
-        );
+                pageable);
+//        String trimmedTagName = null;
+//        if (StringUtils.hasText(tagName)) {
+//            trimmedTagName = tagName.trim();
+//        }
+//        return communityRepository.findCommunitySummaries(
+//                category,
+//                trimmedTagName,
+//                pageable
+//        );
     }
 
     /**
@@ -195,7 +201,7 @@ public class CommunityService {
 
         /* 이미지 objectPath 가져온 뒤 → 60초짜리 서명 URL 변환 */
         List<String> imageUrls = imageRepository.findByCommunityId(communityId).stream()
-                .map(Image::getImageUrl)
+                .map(Image::getObjectPath)
                 .map(p -> communityImageService.getSignedUrl(p, 60))
                 .toList();
 
@@ -421,7 +427,7 @@ public class CommunityService {
         List<Image> images = objectPaths.stream()
                 .map(path -> Image.builder()
                         .community(community)
-                        .imageUrl(path)      // Supabase object path 그대로
+                        .objectPath(path)      // Supabase object path 그대로
                         .build())
                 .toList();
 

--- a/src/main/java/com/team05/linkup/domain/community/domain/Image.java
+++ b/src/main/java/com/team05/linkup/domain/community/domain/Image.java
@@ -29,6 +29,9 @@ public class Image extends BaseEntity {
     @JoinColumn(name = "community_id")
     private Community community;
 
-    @Column(name = "image_url", nullable = false)
-    private String imageUrl;
+    @Column(name = "object_path", length = 512, nullable = false)
+    private String objectPath;     // imageUrl → objectPath 로 변경
+
+//    @Column(name = "image_url", nullable = false)
+//    private String imageUrl;
 }


### PR DESCRIPTION
## ✨ PR 종류
- [x] 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 🛠️ 작업 요약
Supabase Storage 업로드가 500을 반환하던 문제를 해결하고  
`images` 테이블을 **object_path 단일 컬럼** 구조로 통일했습니다.

## 📝 작업 상세
- StorageClient 설정 버그 수정(apiKey, URL 순서)
- CommunityImageService: objectPath 업로드·타임아웃 30s·에러 로깅
- Image 엔티티 및 관련 Service/Controller 전면 수정
- 단일 SQL(`images_object_path_canonical.sql`)로 DB 컬럼명 통합
- 업로드 성공 시 201 Created & objectPath 리스트 반환
![image](https://github.com/user-attachments/assets/1c07475e-2526-4f18-9be1-06649758acab)

## ✅ 체크리스트
- [x] 코드 점검 완료
- [x] 로컬 DB 마이그레이션 적용 및 테스트 통과
- [x] Swagger 문서 최신화
- [ ] 운영 DB 컬럼 변경 적용(배포 전 수동 실행)

## 📚 기타
- 프론트엔드: 기존 `imageUrl` 대신 `objectPath` 또는 서명 URL 사용 필요
- 기존 데이터도 스크립트가 자동 이동 처리합니다.
