### PR TITLE
[feat] 프로필 설정 응답에 displayName 및 시군구 한글명 추가

### DIFF
--- a/src/main/java/com/team05/linkup/domain/user/application/ProfileService.java
+++ b/src/main/java/com/team05/linkup/domain/user/application/ProfileService.java
@@ -405,15 +405,29 @@ public class ProfileService {
         User user = userRepository.findByNickname(nickname)
                 .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
 
+        // 시군구 이름 조회
+        String sigunguName = Optional.ofNullable(user.getArea())
+                .flatMap(area -> Optional.ofNullable(user.getSigunguCode())
+                        .flatMap(code -> sigunguRepository.findByIdAreacodeAndIdSigungucode(area.getAreacode(), code))
+                        .map(Sigungu::getSigunguname))
+                .orElse(null);
+
         return ProfileSettingsResponseDTO.builder()
                 .nickname(user.getNickname())
                 .profileImageUrl(user.getProfileImageUrl())
                 .introduction(user.getIntroduction())
                 .interest(user.getInterest())
+                .interestDisplayName(user.getInterest().getDisplayName())
+
                 .activityTime(user.getActivityTime())
+                .activityTimeDisplayName(user.getActivityTime().getDisplayName())
+
                 .activityType(user.getActivityType())
+                .activityTypeDisplayName(user.getActivityType().getDisplayName())
+
                 .area(user.getArea() != null ? user.getArea().getAreaName() : null)
-                .sigungu(user.getSigunguCode())
+                .sigunguCode(user.getSigunguCode())
+                .sigunguName(sigunguName)
                 .tags(user.parseTags())
 
                 // 🔹 멘토 전용 필드

--- a/src/main/java/com/team05/linkup/domain/user/dto/ProfileSettingsResponseDTO.java
+++ b/src/main/java/com/team05/linkup/domain/user/dto/ProfileSettingsResponseDTO.java
@@ -21,12 +21,18 @@ public class ProfileSettingsResponseDTO {
 
     // 🔹 활동 관련
     private Interest interest;
+    private String interestDisplayName;
+
     private ActivityTime activityTime;
+    private String activityTimeDisplayName;
+
     private ActivityType activityType;
+    private String activityTypeDisplayName;
 
     // 🔹 지역 정보
     private String area;        // Area 엔티티에서 getAreaName()으로 추출
-    private Integer sigungu;    // 구/군 코드
+    private Integer sigunguCode;    // 구/군 코드
+    private String sigunguName;    // ex. "마포구"
 
     // 🔹 태그
     private List<String> tags;  // ','로 구분된 String → List<String>으로 변환


### PR DESCRIPTION
## ✨ PR 종류

- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 🛠️ 작업 요약

- 프로필 설정 조회 API (`GET /v1/users/{nickname}/profile`)에 displayName 필드 추가
- 시군구 코드(sigunguCode) 외에 시군구 한글명(sigunguName) 응답 추가

## 📝 작업 상세

- 프론트에서 enum code만 받아도 한글로 표시 가능하도록 displayName 필드 제공
- 시군구도 마찬가지로 code + name 함께 응답
- 기존 PATCH 요청 구조(`code` 기반)는 그대로 유지, **프론트에서 displayName → code 매핑 처리 필요**
- 구조적 리팩토링은 추후 `EnumResponseDTO<T>` 등으로 개선 가능

## ✅ 체크리스트

- [x] 코드 점검 완료
- [x] 테스트 통과
- [x] 문서/주석 최신화

## 📚 기타

- 구조적 리팩토링은 추후 `EnumResponseDTO<T>` 등으로 개선 가능
- 프론트에서 displayName을 표기하고 code로 전송하면 그대로 백엔드에서 enum으로 매핑됨