### PR TITLE
[feat] 프로필 설정 응답에 areaCode 필드 추가

### DIFF
--- a/src/main/java/com/team05/linkup/domain/user/application/ProfileService.java
+++ b/src/main/java/com/team05/linkup/domain/user/application/ProfileService.java
@@ -425,6 +425,7 @@ public class ProfileService {
                 .activityType(user.getActivityType())
                 .activityTypeDisplayName(user.getActivityType().getDisplayName())
 
+                .areaCode(user.getArea() != null ? user.getArea().getAreacode() : null)
                 .area(user.getArea() != null ? user.getArea().getAreaName() : null)
                 .sigunguCode(user.getSigunguCode())
                 .sigunguName(sigunguName)

--- a/src/main/java/com/team05/linkup/domain/user/dto/ProfileSettingsResponseDTO.java
+++ b/src/main/java/com/team05/linkup/domain/user/dto/ProfileSettingsResponseDTO.java
@@ -30,7 +30,8 @@ public class ProfileSettingsResponseDTO {
     private String activityTypeDisplayName;
 
     // 🔹 지역 정보
-    private String area;        // Area 엔티티에서 getAreaName()으로 추출
+    private Integer areaCode;
+    private String area;        // ex. "서울"
     private Integer sigunguCode;    // 구/군 코드
     private String sigunguName;    // ex. "마포구"
 


### PR DESCRIPTION
## ✨ PR 종류

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 🛠️ 작업 요약

- 프로필 설정 조회 응답에 areaCode(지역 코드) 필드 추가

## 📝 작업 상세

- GET /v1/users/{nickname}/profile 응답에 지역 코드(areaCode) 필드 추가
- 기존에는 지역명(area)만 존재하여 프론트에서 코드 매핑이 어려웠음
- areaName + areaCode를 함께 응답하도록 구조 개선
- 관련 DTO(ProfileSettingsResponseDTO) 및 서비스(ProfileService) 로직 수정

## ✅ 체크리스트

- [x] 코드 점검 완료
- [x] 테스트 통과
- [x] 문서/주석 최신화

## 📚 기타
