### PR TITLE
[refactor] 기존 /v1/users/me → /v1/authUser/me 로 경로 분리

### DIFF
--- a/src/main/java/com/team05/linkup/domain/user/api/LoginUserInfoController.java
+++ b/src/main/java/com/team05/linkup/domain/user/api/LoginUserInfoController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.Optional;
 
 @RestController
-@RequestMapping("/v1/users")
+@RequestMapping("/v1/authUser")
 @Tag(name = "로그인 유저 API", description = "현재 로그인한 유저의 기본 정보(nickname, role) 조회용 API")
 @RequiredArgsConstructor
 public class LoginUserInfoController {


### PR DESCRIPTION
## ✨ PR 종류

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 🛠️ 작업 요약

- /v1/users/me → /v1/authUser/me로 API 경로 분리

## 📝 작업 상세

- 작업 1: 기존 로그인 사용자 정보 조회 API에서 TEMP 유저 접근 문제로 인해 경로 분리
- 작업 2: 시큐리티 설정을 유지하면서 TEMP 유저도 접근 가능하도록 /v1/authUser/me로 이동 처리

## ✅ 체크리스트

- [x] 코드 점검 완료
- [ ] 테스트 통과
- [ ] 문서/주석 최신화

## 📚 기타
