### PR TITLE
[fix] 게시글(community) content 컬럼 타입(크기) 변경 tinytext -> text

### DIFF
--- a/src/main/java/com/team05/linkup/domain/community/domain/Community.java
+++ b/src/main/java/com/team05/linkup/domain/community/domain/Community.java
@@ -49,7 +49,7 @@ public class Community extends BaseEntity {
      * 게시글 내용 (긴 텍스트)
      */
     @Lob
-    @Column(nullable = false)
+    @Column(length = 65535, nullable = false)
     private String content;
 
     /**


### PR DESCRIPTION
## ✨ PR 종류
- [ ] 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 🛠️ 작업 요약
- content 컬럼 타입(크기) 변경 tinytext -> text

## 📝 작업 상세
- mysql에서 @Lob 단독 설정은 tinytext(255byte) 타입으로 설정되서 게시글 내용 저장에 문제 발생
- 65,535바이트인 text + @Lob으로 변경
## ✅ 체크리스트
- [x] 코드 점검 완료
- [x] 테스트 통과
- [x] 문서/주석 최신화

## 📚 기타