### PR TITLE
[feat] 마이페이지 게시글 카테고리 필터 기능 및 QnA 관심 태그 기반 추천 로직 리팩토링

### DIFF
--- a/src/main/java/com/team05/linkup/domain/community/infrastructure/CommunityRepository.java
+++ b/src/main/java/com/team05/linkup/domain/community/infrastructure/CommunityRepository.java
@@ -390,4 +390,43 @@ public interface CommunityRepository extends JpaRepository<Community, String>, C
         WHERE l.user_id = :userId
     """, nativeQuery = true)
     Page<Object[]> findLikesByUserId(@Param("userId") String userId, Pageable pageable);
+
+
+    @Query(
+            value = """
+        SELECT 
+            c.id,
+            c.updated_at,
+            c.category,
+            c.title,
+            c.content,
+            c.view_count,
+            c.like_count,
+            (
+                SELECT COUNT(*) 
+                FROM comments cm 
+                WHERE cm.community_id = c.id
+            ) AS comment_count
+        FROM community c
+        JOIN user u ON c.user_id = u.id
+        WHERE u.nickname = :nickname
+          AND c.category = :category
+        ORDER BY c.updated_at DESC
+        """,
+            countQuery = """
+        SELECT COUNT(*)
+        FROM community c
+        JOIN user u ON c.user_id = u.id
+        WHERE u.nickname = :nickname
+          AND c.category = :category
+        """,
+            nativeQuery = true
+    )
+    Page<Object[]> findMyPostsByCategoryPaged(
+            @Param("nickname") String nickname,
+            @Param("category") String category,
+            Pageable pageable
+    );
+
+
 }

--- a/src/main/java/com/team05/linkup/domain/community/infrastructure/CommunityRepositoryCustom.java
+++ b/src/main/java/com/team05/linkup/domain/community/infrastructure/CommunityRepositoryCustom.java
@@ -14,13 +14,15 @@ public interface CommunityRepositoryCustom {
     /**
      * 멘토의 관심 태그와 일치하는 QnA 게시글 중 최신순으로 N개 조회
      *
-     * @param interest 관심 태그
+     * @param tags 관심 태그
      * @param limit 출력할 게시글 수
      * @return 게시글 요약 DTO 목록
      */
-    List<CommunityQnAPostDTO> findRecentQnAPostsByInterest(String interest, int limit);
+//    List<CommunityQnAPostDTO> findRecentQnAPostsByInterest(String interest, int limit);
+    List<CommunityQnAPostDTO> findRecentQnAPostsByTags(List<String> tags, int limit);
 
-    Page<CommunityQnAPostDTO> findRecentQnAPostsByInterestPaged(String interest, Pageable pageable);
+    Page<CommunityQnAPostDTO> findRecentQnAPostsByInterestPaged(List<String> interests, Pageable pageable);
+
 
     /**
      * 다양한 조건으로 게시글을 고급 검색합니다.

--- a/src/main/java/com/team05/linkup/domain/community/infrastructure/CommunityRepositoryCustomImpl.java
+++ b/src/main/java/com/team05/linkup/domain/community/infrastructure/CommunityRepositoryCustomImpl.java
@@ -32,25 +32,30 @@ public class CommunityRepositoryCustomImpl implements CommunityRepositoryCustom 
      * CommunityQnAPostDTO의 communityTag 필드에는 입력된 interestTagName 값을 채워줍니다.
      */
     @Override
-    public List<CommunityQnAPostDTO> findRecentQnAPostsByInterest(String interestTag, int limit) {
+    public List<CommunityQnAPostDTO> findRecentQnAPostsByTags(List<String> tags, int limit) {
         return queryFactory
                 .select(new QCommunityQnAPostDTO(
                         community.id,
                         user.nickname,
                         user.profileImageUrl,
-                        community.updatedAt.stringValue(), // ZonedDateTime → String
+                        community.updatedAt.stringValue(),
                         community.title,
                         community.content,
-                        Expressions.constant(interestTag),
-                        comment.id.count().intValue()     // 댓글 수 실시간 계산
+                        Expressions.constant(""),
+//                        // ✅ 태그 이름들을 쉼표로 묶은 문자열로 반환
+//                        Expressions.stringTemplate(
+//                                "(SELECT STRING_AGG(t.name, ',') FROM community_tag_join ctj JOIN tag t ON ctj.tag_id = t.id WHERE ctj.community_id = {0})",
+//                                community.id
+//                        ),
+                        comment.id.count().intValue()
                 ))
                 .from(community)
                 .join(community.user, user)
-                .leftJoin(community.tags, tag) // Community의 tags 컬렉션과 QTag 조인
-                .leftJoin(comment).on(comment.communityId.eq(community.id)) // 댓글 테이블과 연결
+                .leftJoin(community.tags, tag)
+                .leftJoin(comment).on(comment.communityId.eq(community.id))
                 .where(
-                        community.category.eq(CommunityCategory.QUESTION)
-                                .and(tag.name.eq(interestTag))
+                        community.category.eq(CommunityCategory.QUESTION),
+                        tag.name.in(tags)
                 )
                 .groupBy(
                         community.id,
@@ -65,12 +70,47 @@ public class CommunityRepositoryCustomImpl implements CommunityRepositoryCustom 
                 .fetch();
     }
 
+//    @Override
+//    public List<CommunityQnAPostDTO> findRecentQnAPostsByInterest(String interestTag, int limit) {
+//        return queryFactory
+//                .select(new QCommunityQnAPostDTO(
+//                        community.id,
+//                        user.nickname,
+//                        user.profileImageUrl,
+//                        community.updatedAt.stringValue(), // ZonedDateTime → String
+//                        community.title,
+//                        community.content,
+//                        Expressions.constant(interestTag),
+//                        comment.id.count().intValue()     // 댓글 수 실시간 계산
+//                ))
+//                .from(community)
+//                .join(community.user, user)
+//                .leftJoin(community.tags, tag) // Community의 tags 컬렉션과 QTag 조인
+//                .leftJoin(comment).on(comment.communityId.eq(community.id)) // 댓글 테이블과 연결
+//                .where(
+//                        community.category.eq(CommunityCategory.QUESTION)
+//                                .and(tag.name.containsIgnoreCase(interestTag))  // ✅ 부분 일치로 완화
+//                )
+//                .groupBy(
+//                        community.id,
+//                        user.nickname,
+//                        user.profileImageUrl,
+//                        community.updatedAt,
+//                        community.title,
+//                        community.content
+//                )
+//                .orderBy(community.updatedAt.desc())
+//                .limit(limit)
+//                .fetch();
+//    }
+
     /**
      * 멘토의 관심 태그 이름과 일치하는 QnA 게시글을 페이징하여 조회.
      * CommunityQnAPostDTO의 communityTag 필드에는 입력된 interestTagName 값을 채워줍니다.
      */
     @Override
-    public Page<CommunityQnAPostDTO> findRecentQnAPostsByInterestPaged(String interestTag, Pageable pageable) {
+    public Page<CommunityQnAPostDTO> findRecentQnAPostsByInterestPaged(List<String> interests, Pageable pageable)
+    {
 
         // 전체 게시글 조회 쿼리
         List<CommunityQnAPostDTO> content = queryFactory
@@ -81,7 +121,12 @@ public class CommunityRepositoryCustomImpl implements CommunityRepositoryCustom 
                         community.updatedAt.stringValue(),
                         community.title,
                         community.content,
-                        Expressions.constant(interestTag),
+                        Expressions.constant(""),
+//                        // ✅ 실제 태그 이름들을 ,로 묶어 반환
+//                        Expressions.stringTemplate(
+//                                "(SELECT STRING_AGG(t.name, ',') FROM community_tag_join ctj JOIN tag t ON ctj.tag_id = t.id WHERE ctj.community_id = {0})",
+//                                community.id
+//                        ),
                         comment.id.count().intValue()
                 ))
                 .from(community)
@@ -90,7 +135,7 @@ public class CommunityRepositoryCustomImpl implements CommunityRepositoryCustom 
                 .leftJoin(comment).on(comment.communityId.eq(community.id))
                 .where(
                         community.category.eq(CommunityCategory.QUESTION),
-                        tag.name.eq(interestTag)
+                        tag.name.in(interests)
                 )
                 .groupBy(
                         community.id,
@@ -107,12 +152,12 @@ public class CommunityRepositoryCustomImpl implements CommunityRepositoryCustom 
 
         // 총 개수 조회 쿼리
         Long count = queryFactory
-                .select(community.count())
+                .select(community.countDistinct())
                 .from(community)
                 .leftJoin(community.tags, tag)
                 .where(
                         community.category.eq(CommunityCategory.QUESTION),
-                        tag.name.eq(interestTag)
+                        tag.name.in(interests)
                 )
                 .fetchOne();
 

--- a/src/main/java/com/team05/linkup/domain/user/api/ProfileController.java
+++ b/src/main/java/com/team05/linkup/domain/user/api/ProfileController.java
@@ -15,6 +15,7 @@ import com.team05.linkup.domain.user.domain.User;
 import com.team05.linkup.domain.user.dto.*;
 import com.team05.linkup.domain.user.infrastructure.UserRepository;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -33,8 +34,10 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @RestController
 @RequestMapping("/v1/users")
@@ -114,10 +117,31 @@ public class ProfileController {
     }
 
     @GetMapping("/{nickname}/activity/more-details")
-    @Operation(summary = "나의 활동 내역 조회 more-details [매칭/재능/게시글/댓글]", description = "내가 신청한 매칭(my-matches), 내가 등록한 재능 목록(my-talents), 내가 작성한 게시글(my-posts), 내가 작성한 댓글(my-comments) 타입에 따라 관련 데이터를 자세히 조회합니다.")
+    @Operation(
+            summary = "나의 활동 내역 조회 more-details",
+            description = """
+        활동 종류(type)에 따라 상세 조회가 가능합니다.
+        - type=my-posts: 내가 작성한 게시글 목록
+          - 이 경우 filter 파라미터를 추가로 사용할 수 있습니다.
+          - 허용값: all, QUESTION, INFO, REVIEW, FREE
+        - type=my-talents: 등록한 재능
+        - type=my-comments: 작성한 댓글
+        - type=my-matches: 신청한 매칭
+    """
+    )
     public ResponseEntity<ApiResponse<?>> getMoreDetails(
             @PathVariable String nickname,
             @RequestParam("type") String type,
+
+
+            @Parameter(
+                    name = "filter",
+                    description = "게시글 카테고리 필터 (type이 'my-posts'일 때만 사용)\n허용값: all, QUESTION, INFO, REVIEW, FREE",
+                    example = "REVIEW"
+            )
+
+            @RequestParam(value = "filter",  required = false) String filter,    // 필터 추가
+
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "10") int size,
             @AuthenticationPrincipal UserPrincipal userPrincipal // ✅ 여기서 닫기
@@ -125,22 +149,33 @@ public class ProfileController {
         return switch (type) {
             // 재능 목록 more-details
             case "my-talents" -> {
-                ActivityMoreDetailsResponseDTO<CommunityTalentSummaryDTO> result =
-                        mentorProfileService.getMyTalentsMoreDetails(nickname, userPrincipal, page, size);
+                // ❗ filter 무시
+                var result = mentorProfileService.getMyTalentsMoreDetails(nickname, userPrincipal, page, size);
                 yield ResponseEntity.ok(ApiResponse.success(result));
             }
 
             // 내가 쓴 게시글 more-details
             case "my-posts" -> {
-                ActivityMoreDetailsResponseDTO<MyPostResponseDTO> dto =
-                        profileService.getMyPostsMoreDetails(nickname, userPrincipal, page, size);
+                // ✅ filter 유효성 검사
+                // ✅ 소문자로 통일
+                // ✅ null or 빈 값까지 안전하게 처리
+                String validatedFilter = (filter == null || filter.isBlank()) ? "all" : filter.toLowerCase().trim();
+                Set<String> allowedFilters = Set.of("all", "question", "info", "review", "free");
+
+                if (!allowedFilters.contains(validatedFilter)) {
+                    yield ResponseEntity.badRequest().body(ApiResponse.error(
+                            ResponseCode.INVALID_INPUT_VALUE,
+                            "유효하지 않은 filter 값입니다. 허용값: all, QUESTION, INFO, REVIEW, FREE"
+                    ));
+                }
+
+                var dto = profileService.getMyPostsMoreDetails(nickname, userPrincipal, page, size, validatedFilter);
                 yield ResponseEntity.ok(ApiResponse.success(dto));
             }
 
             // 내가 쓴 댓글 more-details
             case "my-comments" -> {
-                ActivityMoreDetailsResponseDTO<MyCommentResponseDTO> dto =
-                        profileService.getMyCommentsMoreDetails(nickname, userPrincipal, page, size);
+                var dto = profileService.getMyCommentsMoreDetails(nickname, userPrincipal, page, size);
                 yield ResponseEntity.ok(ApiResponse.success(dto));
             }
 
@@ -225,18 +260,21 @@ public class ProfileController {
             @PathVariable String nickname,
             @AuthenticationPrincipal UserPrincipal userPrincipal
     ) {
+        System.out.println("🔎 [DEBUG] userPrincipal = " + userPrincipal);
+        System.out.println("🔎 [DEBUG] path nickname = " + nickname);
+
 //         여기부터 주석 또는 삭제
-//        if (userPrincipal == null) {
-//            logger.warn("⚠️ 인증 객체가 null입니다. Swagger 테스트 중일 수 있습니다.");
-//            Optional<User> fallbackUserOpt = userRepository.findByNickname(nickname);
-//            if (fallbackUserOpt.isEmpty()) {
-//                return ResponseEntity.status(HttpStatus.NOT_FOUND)
-//                        .body(ApiResponse.error(ResponseCode.ENTITY_NOT_FOUND, "사용자를 찾을 수 없습니다."));
-//            }
-//
-//            User fallbackUser = fallbackUserOpt.get();
-//            userPrincipal = new UserPrincipal(fallbackUser.getProviderId(), fallbackUser.getProvider());
-//        }
+        if (userPrincipal == null) {
+            logger.warn("⚠️ 인증 객체가 null입니다. Swagger 테스트 중일 수 있습니다.");
+            Optional<User> fallbackUserOpt = userRepository.findByNickname(nickname);
+            if (fallbackUserOpt.isEmpty()) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .body(ApiResponse.error(ResponseCode.ENTITY_NOT_FOUND, "사용자를 찾을 수 없습니다."));
+            }
+
+            User fallbackUser = fallbackUserOpt.get();
+            userPrincipal = new UserPrincipal(fallbackUser.getProviderId(), fallbackUser.getProvider());
+        }
         // 여기까지
 
         Optional<User> userOpt = userRepository.findByProviderAndProviderId(
@@ -293,18 +331,52 @@ public class ProfileController {
         User user = userOpt.get();
         Pageable pageable = PageRequest.of(page, size);
 
-        return switch (type) {
-            case "interest-qna" -> {
-                String interest = String.valueOf(userRepository.findInterestByNickname(nickname));
-                if (interest == null) {
-                    yield ResponseEntity.status(HttpStatus.NOT_FOUND)
-                            .body(ApiResponse.error(ResponseCode.ENTITY_NOT_FOUND, "관심 태그 정보를 찾을 수 없습니다."));
-                }
-
-                Page<CommunityQnAPostResponseDTO> result =
-                        matchingPageFacade.getRecentQnAPostsByInterestPaged(interest, page, size);
-                yield ResponseEntity.ok(ApiResponse.success(result));
+        if (type.equals("interest-qna")) {
+            String profileTag = user.getProfileTag();
+            if (profileTag == null || profileTag.isBlank()) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .body(ApiResponse.error(ResponseCode.ENTITY_NOT_FOUND, "관심 태그 정보가 없습니다."));
             }
+
+            List<String> userTags = Arrays.stream(profileTag.split(","))
+                    .map(String::trim)
+                    .filter(s -> !s.isBlank())
+                    .toList();
+
+            Page<CommunityQnAPostResponseDTO> result =
+                    matchingPageFacade.getRecentQnAPostsByInterestPaged(userTags, page, size);
+            return ResponseEntity.ok(ApiResponse.success(result));
+        }
+
+        return switch (type) {
+
+//            case "interest-qna" -> {
+//                // 🔄 profileTag 기반으로 태그 리스트 추출
+//                String profileTag = user.getProfileTag(); // 예: "백엔드, Node.js, Django"
+//                if (profileTag == null || profileTag.isBlank()) {
+//                    yield ResponseEntity.status(HttpStatus.NOT_FOUND)
+//                            .body(ApiResponse.error(ResponseCode.ENTITY_NOT_FOUND, "관심 태그 정보가 없습니다."));
+//                }
+//
+//                // 쉼표 기준으로 나눠서 리스트로 변환
+//                List<String> userTags = Arrays.stream(profileTag.split(","))
+//                        .map(String::trim)
+//                        .filter(s -> !s.isBlank())
+//                        .toList();
+//
+//                // ✅ 이제 userTags를 넘겨줘야 함!
+//                Page<CommunityQnAPostResponseDTO> result =
+//                        matchingPageFacade.getRecentQnAPostsByInterestPaged(userTags, page, size);
+////                String interest = String.valueOf(userRepository.findInterestByNickname(nickname));
+////                if (interest == null) {
+////                    yield ResponseEntity.status(HttpStatus.NOT_FOUND)
+////                            .body(ApiResponse.error(ResponseCode.ENTITY_NOT_FOUND, "관심 태그 정보를 찾을 수 없습니다."));
+////                }
+////
+////                Page<CommunityQnAPostResponseDTO> result =
+////                        matchingPageFacade.getRecentQnAPostsByInterestPaged(interest, page, size);
+////                yield ResponseEntity.ok(ApiResponse.success(result));
+//            }
 
             case "received-reviews" -> {
                 Page<ReceivedReviewDTO> result =

--- a/src/main/java/com/team05/linkup/domain/user/application/MatchingPageFacade.java
+++ b/src/main/java/com/team05/linkup/domain/user/application/MatchingPageFacade.java
@@ -39,7 +39,14 @@ public class MatchingPageFacade {
     public MyMatchingPageDTO getMatchingPageData(User mentor) {
         return MyMatchingPageDTO.builder()
                 .reviews(reviewService.getReviewsForMentor(mentor.getId(), 2))
-                .communityQnAs(getRecentQnAByInterest(mentor.getInterest().name(), 2))
+//                .communityQnAs(getRecentQnAByInterest(mentor.getInterest().name(), 2))
+                .communityQnAs(getRecentQnAByInterest(
+                        Arrays.stream(mentor.getProfileTag().split(","))
+                                .map(String::trim)
+                                .filter(s -> !s.isBlank())
+                                .toList(),
+                        2
+                ))
                 .ongoingMatchings(ongoingMatchingService.getOngoingMatchingsForMentor(mentor.getId(), 2))
                 .stats(mentorProfileService.getMentoringStats(UUID.fromString(mentor.getId())))
                 .build();
@@ -48,8 +55,8 @@ public class MatchingPageFacade {
     /**
      * 관심 분야 기반 최근 QnA 게시글 조회
      */
-    private List<CommunityQnAPostResponseDTO> getRecentQnAByInterest(String interest, int limit) {
-        List<CommunityQnAPostDTO> rawResults = communityRepository.findRecentQnAPostsByInterest(interest, limit);
+    private List<CommunityQnAPostResponseDTO> getRecentQnAByInterest(List<String> userTags, int limit) {
+        List<CommunityQnAPostDTO> rawResults = communityRepository.findRecentQnAPostsByTags(userTags, limit);
 
         return rawResults.stream()
                 .map(dto -> CommunityQnAPostResponseDTO.builder()
@@ -64,6 +71,22 @@ public class MatchingPageFacade {
                         .build())
                 .collect(Collectors.toList());
     }
+//    private List<CommunityQnAPostResponseDTO> getRecentQnAByInterest(String interest, int limit) {
+//        List<CommunityQnAPostDTO> rawResults = communityRepository.findRecentQnAPostsByInterest(interest, limit);
+//
+//        return rawResults.stream()
+//                .map(dto -> CommunityQnAPostResponseDTO.builder()
+//                        .postId(dto.getPostId())
+//                        .nickname(dto.getNickname())
+//                        .profileImageUrl(dto.getProfileImageUrl())
+//                        .createdAt(dto.getCreatedAt())
+//                        .title(dto.getTitle())
+//                        .content(dto.getContent())
+//                        .tags(parseTags(dto.getTagName()))
+//                        .commentCount(dto.getCommentCount())
+//                        .build())
+//                .collect(Collectors.toList());
+//    }
 
     /**
      * 태그 문자열 → List<String> 변환
@@ -75,9 +98,9 @@ public class MatchingPageFacade {
                 .collect(Collectors.toList());
     }
 
-    public Page<CommunityQnAPostResponseDTO> getRecentQnAPostsByInterestPaged(String interest, int page, int size) {
+    public Page<CommunityQnAPostResponseDTO> getRecentQnAPostsByInterestPaged(List<String> tags, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<CommunityQnAPostDTO> rawResults = communityRepository.findRecentQnAPostsByInterestPaged(interest, pageable);
+        Page<CommunityQnAPostDTO> rawResults = communityRepository.findRecentQnAPostsByInterestPaged(tags, pageable);
 
         return rawResults.map(dto -> CommunityQnAPostResponseDTO.builder()
                 .postId(dto.getPostId())

--- a/src/main/java/com/team05/linkup/domain/user/application/MentorProfileService.java
+++ b/src/main/java/com/team05/linkup/domain/user/application/MentorProfileService.java
@@ -149,10 +149,27 @@ public class MentorProfileService {
         // 2. 관심 분야별 멘토링 횟수 (기존 쿼리 그대로 유지)
         List<Object[]> rawResults = mentoringRepository.countMentoringByInterest(mentorUserId);
         List<InterestCountDTO> interestStats = rawResults.stream()
-                .map(row -> InterestCountDTO.builder()
-                        .interest(((Interest) row[0]).name())
-                        .count((Long) row[1])
-                        .build())
+                .map(row -> {
+                    String interestStr = String.valueOf(row[0]);
+                    Long count = (Long) row[1];
+
+                    try {
+                        Interest interestEnum = Interest.valueOf(interestStr);
+
+                        return InterestCountDTO.builder()
+                                .interest(interestEnum.name())                 // "WEB_DEV"
+                                .displayName(interestEnum.getDisplayName())    // "웹개발"
+                                .count(count)
+                                .build();
+                    } catch (IllegalArgumentException | NullPointerException e) {
+                            // 매칭 실패 시 fallback 처리
+                            return InterestCountDTO.builder()
+                                    .interest(interestStr)      // 그대로 전달
+                                    .displayName(interestStr) // 영어로라도 표시
+                                    .count(count)
+                                    .build();
+                    }
+                })
                 .collect(Collectors.toList());
 
         return MentorStatsDTO.builder()

--- a/src/main/java/com/team05/linkup/domain/user/dto/InterestCountDTO.java
+++ b/src/main/java/com/team05/linkup/domain/user/dto/InterestCountDTO.java
@@ -2,12 +2,13 @@ package com.team05.linkup.domain.user.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 
-@Data
+@Getter
 @Builder
 @AllArgsConstructor
 public class InterestCountDTO {
     private String interest; // e.g., WEB_DEV
+    private String displayName; // e.g., "웹개발"
     private Long count;         // e.g., 18
 }


### PR DESCRIPTION
## ✨ PR 종류

- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 🛠️ 작업 요약

- 마이페이지 게시글 필터 기능 추가 및 QnA 관심 태그 기반 추천 로직 리팩토링

## 📝 작업 상세

- 작업 1: QnA 추천 로직에서 Interest enum 기반 추천 제거 → profileTag 기반 태그 매칭으로 변경
- 작업 2: 게시글 조회 시 filter 파라미터 유효성 검사 및 ALL 분기 처리 추가

## ✅ 체크리스트

- [x] 코드 점검 완료
- [x] 테스트 통과
- [x] 문서/주석 최신화

## 📚 기타

- 게시글 필터에서 TALENT는 제외되며, 허용값은 all, QUESTION, INFO, REVIEW, FREE 입니다.
(필터링 기능은 my-posts에만 추가)