### PR TITLE
[fix] 리뷰 관련 API 수정, 요청/응답 DTO 수정

### DIFF
--- a/src/main/java/com/team05/linkup/common/config/SecurityConfig.java
+++ b/src/main/java/com/team05/linkup/common/config/SecurityConfig.java
@@ -103,7 +103,7 @@ public class SecurityConfig {
                 "https://frontend.linkup.o-r.kr",
                 "http://frontend.linkup.o-r.kr:3000"
         ));
-        config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         config.setAllowedHeaders(Arrays.asList(
                 "Authorization",
                 "Content-Type",

--- a/src/main/java/com/team05/linkup/domain/mentoring/infrastructure/MentoringRepository.java
+++ b/src/main/java/com/team05/linkup/domain/mentoring/infrastructure/MentoringRepository.java
@@ -15,8 +15,12 @@ public interface MentoringRepository extends JpaRepository<MentoringSessions, St
     @Query(value = "SELECT * FROM mentoring_sessions WHERE mentee_user_id = :userId ORDER BY created_at DESC LIMIT :limit", nativeQuery = true)
     List<MentoringSessions> findByMenteeUserIdWithLimit(@Param("userId") String userId, @Param("limit") int limit);
 
-    @Query("SELECT m FROM MentoringSessions m WHERE m.mentee.id = :menteeId AND m.status = :status")
-    List<MentoringSessions> findByMenteeIdAndStatus(@Param("menteeId") String menteeId, @Param("status") MentoringStatus status);
+    // 멘티의 완료된 멘토링 세션 중 리뷰가 작성되지 않은 세션만 조회합니다.
+    @Query("SELECT ms FROM MentoringSessions ms " +
+            "WHERE ms.mentee.id = :menteeId " +
+            "AND ms.status = 'COMPLETED' " +
+            "AND NOT EXISTS (SELECT r FROM Review r WHERE r.mentoringSessionId = ms.id)")
+    List<MentoringSessions> findCompletedSessionsWithoutReview(@Param("menteeId") String menteeId);
 
     @Query(value = "SELECT * FROM mentoring_sessions WHERE id = :id", nativeQuery = true)
     Optional<MentoringSessions> findMentoringSessionById(@org.springframework.data.repository.query.Param("id") String id);

--- a/src/main/java/com/team05/linkup/domain/review/api/MenteeReviewController.java
+++ b/src/main/java/com/team05/linkup/domain/review/api/MenteeReviewController.java
@@ -7,6 +7,7 @@ import com.team05.linkup.domain.review.application.ReviewService;
 import com.team05.linkup.domain.review.dto.MyCompletedMentoringDTO;
 import com.team05.linkup.domain.review.dto.ReviewRequestDTO;
 import com.team05.linkup.domain.review.dto.ReviewResponseDTO;
+import com.team05.linkup.domain.review.dto.ReviewUpdateDTO;
 import com.team05.linkup.domain.user.domain.User;
 import com.team05.linkup.domain.user.infrastructure.UserRepository;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,8 +17,6 @@ import lombok.RequiredArgsConstructor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -101,7 +100,7 @@ public class MenteeReviewController {
 
     @PatchMapping("/review/{reviewId}")
     @Operation(summary = "리뷰 수정", description = "기존에 작성된 리뷰를 새로운 내용으로 업데이트합니다.")
-    public ResponseEntity<ApiResponse> updateReview(@AuthenticationPrincipal UserPrincipal userPrincipal, @PathVariable String reviewId,@RequestBody ReviewRequestDTO reviewRequestDTO) {
+    public ResponseEntity<ApiResponse> updateReview(@AuthenticationPrincipal UserPrincipal userPrincipal, @PathVariable String reviewId, @RequestBody ReviewUpdateDTO reviewUpdateDTO) {
         Optional<User> userOpt = userRepository.findByProviderAndProviderId(
                 userPrincipal.provider(), userPrincipal.providerId());
         if (userOpt.isEmpty())
@@ -109,7 +108,7 @@ public class MenteeReviewController {
                     .body(ApiResponse.error(ResponseCode.ENTITY_NOT_FOUND, "프로필을 찾을 수 없습니다."));
 
         try {
-            reviewService.updateReview(userOpt.get(), reviewId, reviewRequestDTO);
+            reviewService.updateReview(userOpt.get(), reviewId, reviewUpdateDTO);
             return ResponseEntity.ok(ApiResponse.created("리뷰가 성공적으로 수정되었습니다."));
         } catch (ConstraintViolationException ex) {
             // 유효성 검증 실패 처리

--- a/src/main/java/com/team05/linkup/domain/review/dto/ReviewResponseDTO.java
+++ b/src/main/java/com/team05/linkup/domain/review/dto/ReviewResponseDTO.java
@@ -13,19 +13,20 @@ import java.math.BigDecimal;
 @Builder
 public class ReviewResponseDTO {
 
-    private String mentoringSessionId;  // 멘토링 세션 ID
+    private String reviewId;  // 리뷰 ID
     private String title;  // 리뷰 제목
     private String content;  // 리뷰 내용
     private BigDecimal star;  // 리뷰 별점 (0.0 ~ 5.0)
     private Interest interest;  // 관심사 (ENUM)
 
     private String mentorName; // 멘토 이름
-    private String profileImageUrl;// 멘토 프로필 이미지 URL
+    private String profileImageUrl; // 멘토 프로필 이미지 URL
+    private String createdAt; // 리뷰 작성일
 
     // 생성된 DTO 객체에서 엔티티로 변환할 수 있는 메소드
     public static Review toEntity(ReviewResponseDTO dto) {
         return Review.builder()
-                .mentoringSessionId(dto.getMentoringSessionId())
+                .id(dto.getReviewId())
                 .title(dto.getTitle())
                 .content(dto.getContent())
                 .star(dto.getStar())

--- a/src/main/java/com/team05/linkup/domain/review/dto/ReviewUpdateDTO.java
+++ b/src/main/java/com/team05/linkup/domain/review/dto/ReviewUpdateDTO.java
@@ -11,9 +11,8 @@ import java.math.BigDecimal;
 
 @Getter
 @Builder
-public class ReviewRequestDTO {
+public class ReviewUpdateDTO {
 
-    private String mentoringSessionId;  // 멘토링 세션 ID
     private String title;  // 리뷰 제목
     private String content;  // 리뷰 내용
 
@@ -24,9 +23,9 @@ public class ReviewRequestDTO {
     private Interest interest;  // 관심사 (ENUM)
 
     // 생성된 DTO 객체에서 엔티티로 변환할 수 있는 메소드
-    public static Review toEntity(ReviewRequestDTO dto) {
+    public static Review toEntity(ReviewUpdateDTO dto, String reviewId) {
         return Review.builder()
-                .mentoringSessionId(dto.getMentoringSessionId())
+                .id(reviewId)
                 .title(dto.getTitle())
                 .content(dto.getContent())
                 .star(dto.getStar())


### PR DESCRIPTION
## ✨ PR 종류

-   [x] 기능 개선
-   [ ] 버그 수정
-   [ ] 리팩토링
-   [ ] 문서 수정
-   [ ] 기타

## 🛠️ 작업 요약

-   **작성 가능한 멘토링 세션 목록 조회 기능 개선**: 멘티가 리뷰를 작성할 수 있는 **리뷰가 작성되지 않은 멘토링 세션 목록만 조회**하도록 개선했습니다.
-   **멘티 리뷰 작성 기능 추가**: 멘토링 세션 완료 상태 확인 및 리뷰 **중복 작성을 검증**하는 로직을 포함하여 리뷰 작성 기능을 구현했습니다.
-   **기존 리뷰 정보 수정/조회 기능 추가**: 특정 리뷰를 수정하기 위해 조회할 때 해당 리뷰의 **소유권을 확인**하는 로직을 포함했습니다. `ReviewResponseDTO`에 `reviewId`, `mentorName`, `profileImageUrl` 필드가 추가되었습니다.
-   **작성된 멘티 리뷰 수정 기능 추가**: 리뷰 수정 시 **소유권 및 입력 데이터의 유효성을 검증**하며, 기존 리뷰의 ID를 유지하면서 내용을 업데이트합니다. 요청 DTO가 `ReviewRequestDTO`에서 `ReviewUpdateDTO`로 변경되었습니다.
-   **작성된 멘티 리뷰 삭제 기능 추가**: 리뷰 삭제 시에도 해당 리뷰의 **소유권을 확인**하는 로직을 포함했습니다.
-   **특정 사용자의 멘티 리뷰 내역 조회 기능 추가**: 리뷰 내역 조회 시 **조회 권한을 확인**하고, N+1 문제를 방지하기 위한 쿼리 최적화(`findByMenteeIdWithMentorAndMentee`, `findByMentoringSessionIdIn`)를 적용했습니다. 조회된 리뷰 정보에는 `reviewId`, `mentorName`, `profileImageUrl`이 포함됩니다.
-   **CORS 설정에 PATCH 메소드 추가**: 리뷰 수정을 위해 `PATCH` 메소드를 CORS 허용 목록에 추가했습니다.

## 📝 작업 상세

### 멘티 리뷰 기능 구현 (CRUD 및 조회)

-   **작성 대상 멘토링 세션 조회**:
    -   API: `GET /v1/mentee/review`
    -   로그인한 멘티의 `COMPLETED` 상태 멘토링 세션 중 **리뷰가 작성되지 않은 세션**만 조회합니다.
    -   이를 위해 `MentoringRepository`에 `findCompletedSessionsWithoutReview` 쿼리 메소드가 추가되었습니다.
    -   응답은 `MyCompletedMentoringDTO` 형태로 세션 ID와 멘토 이름을 반환합니다.
-   **리뷰 작성**:
    -   API: `POST /v1/mentee/review`
    -   요청은 `ReviewRequestDTO` (세션ID, 제목, 내용, 별점(0.0~5.0), 관심사)를 사용합니다.
    -   **리뷰 중복 검증** 및 해당 멘토링 세션이 **`COMPLETED` 상태인지 검증**합니다.
    -   Bean Validation을 통해 요청 데이터의 유효성을 검사합니다.
    -   유효성 위반 시 `BAD_REQUEST`, 중복 리뷰 시 `CONFLICT`, 무효한 세션 시 `BAD_REQUEST` 오류 코드를 반환합니다.
-   **리뷰 조회 (수정용)**:
    -   API: `GET /v1/mentee/review/{reviewId}`
    -   조회하려는 리뷰가 존재하는지, 그리고 현재 로그인한 사용자가 해당 리뷰의 **소유자인지 확인**합니다.
    -   응답은 `ReviewResponseDTO`로 리뷰 상세 정보를 반환하며, 이 DTO에 `reviewId`, 멘토 이름 (`mentorName`), 멘토 프로필 이미지 URL (`profileImageUrl`) 필드가 추가되었습니다.
    -   리뷰/세션이 없거나 권한이 없는 경우 오류를 반환합니다.
-   **리뷰 수정**:
    -   API: `PATCH /v1/mentee/review/{reviewId}`
    -   요청 DTO는 `ReviewUpdateDTO`로 변경되었습니다. 이 DTO는 제목, 내용, 별점(0.0~5.0), 관심사를 포함합니다.
    -   **리뷰 존재 확인, 소유권 확인, 유효성 검사**를 수행합니다.
    -   기존 리뷰의 ID를 유지하며 제목, 내용, 별점, 관심사 필드를 **새로운 내용으로 업데이트**합니다.
    -   유효성 위반 시 `BAD_REQUEST`, 권한 없음 시 `FORBIDDEN`, 리뷰/세션 없음 시 `BAD_REQUEST` 오류를 반환합니다.
    -   CORS 설정에 `PATCH` 메소드가 추가되었습니다.
-   **리뷰 삭제**:
    -   API: `DELETE /v1/mentee/review/{reviewId}`
    -   **리뷰 존재 확인 및 소유권 확인**을 수행합니다.
    -   권한 없음 시 `FORBIDDEN`, 리뷰/세션 없음 시 `BAD_REQUEST` 오류를 반환합니다.
-   **리뷰 내역 조회**:
    -   API: `GET /v1/mentee/review/list/{nickname}`
    -   `ProfileService.isCurrentUser` 메소드를 사용하여 **조회 권한을 확인**합니다.
    -   `findByMenteeIdWithMentorAndMentee` 등의 쿼리 메소드를 활용하여 N+1 문제를 **방지**했습니다.
    -   응답은 `ReviewResponseDTO` 리스트 형태로 반환되며, 각 리뷰 정보에 `reviewId`, 멘토 이름, 멘토 프로필 이미지 URL이 포함됩니다.
    -   조회 권한 없음 시 `FORBIDDEN`, 사용자 없음 시 `NOT_FOUND` 오류를 반환합니다.

## ✅ 체크리스트

-   [x] 코드 점검 완료
-   [x] 테스트 통과
-   [x] 문서/주석 최신화

## 📚 기타

-   리뷰 작성 전 멘토링 세션 목록 조회 시에는 **멘토링이 완료된 건만** 조회됩니다.