### PR TITLE
[feat] 커뮤니티 게시글 목록 조회 최적화 및 DTO 매핑 로직 개선 및 중앙화

### DIFF
--- a/src/main/java/com/team05/linkup/domain/community/dto/CommunitySummaryResponseDTO.java
+++ b/src/main/java/com/team05/linkup/domain/community/dto/CommunitySummaryResponseDTO.java
@@ -1,7 +1,11 @@
 package com.team05.linkup.domain.community.dto;
 
 import com.team05.linkup.domain.community.domain.CommunityCategory;
+
+import java.sql.Timestamp; // For handling Timestamp from native queries
+import java.time.ZoneId;   // For ZonedDateTime conversion
 import java.time.ZonedDateTime;
+// import java.math.BigInteger; // If native query might return BigInteger for counts
 
 /**
  * 커뮤니티 게시물의 요약 뷰를 나타내는 데이터 전송 객체(DTO).
@@ -31,4 +35,90 @@ public record CommunitySummaryResponseDTO(
         String profileImageUrl,
         Long commentCount
 ) {
+
+    /**
+     * Object 배열로부터 CommunitySummaryResponseDTO 인스턴스를 생성하는 정적 팩토리 메서드입니다.
+     * 배열의 각 요소는 DTO의 필드에 해당하는 특정 순서와 타입을 가져야 합니다.
+     *
+     * @param obj Object 배열. 다음 순서와 타입을 가져야 합니다:
+     * 
+     * id (String)
+     * nickname (String)
+     * title (String)
+     * category (String, CommunityCategory enum 이름)
+     * createdAt (Timestamp 또는 ZonedDateTime)
+     * viewCount (Number)
+     * likeCount (Number)
+     * content (String)
+     * profileImageUrl (String)
+     * commentCount (Number)
+     *
+     * @return 생성된 CommunitySummaryResponseDTO 인스턴스.
+     * @throws IllegalArgumentException 입력 배열이 null이거나, 길이가 맞지 않거나, 필수 요소가 null이거나, 타입 변환에 실패한 경우.
+     */
+    public static CommunitySummaryResponseDTO fromObjectArray(Object[] obj) {
+        if (obj == null || obj.length < 10) {
+            throw new IllegalArgumentException("Input Object array must not be null and have at least 10 elements for CommunitySummaryResponseDTO.");
+        }
+
+        String id = (String) obj[0];
+        String nickname = (String) obj[1];
+        String title = (String) obj[2];
+
+        String categoryString = (String) obj[3];
+        CommunityCategory category;
+        if (categoryString == null || categoryString.trim().isEmpty()) {
+            throw new IllegalArgumentException("Category string cannot be null or empty.");
+        }
+        try {
+            category = CommunityCategory.valueOf(categoryString.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid or unsupported category string: " + categoryString, e);
+        }
+
+        ZonedDateTime createdAt;
+        Object createdAtObj = obj[4];
+        if (createdAtObj instanceof Timestamp) {
+            createdAt = ((Timestamp) createdAtObj).toInstant().atZone(ZoneId.systemDefault());
+        } else if (createdAtObj instanceof ZonedDateTime) {
+            createdAt = (ZonedDateTime) createdAtObj;
+        } else if (createdAtObj == null) {
+            throw new IllegalArgumentException("createdAt cannot be null.");
+        } else {
+            throw new IllegalArgumentException("Unexpected type for createdAt: " + createdAtObj.getClass().getName());
+        }
+
+        Long viewCount = getLongValue(obj[5]);
+        Long likeCount = getLongValue(obj[6]);
+        String content = (String) obj[7];
+        String profileImageUrl = (String) obj[8];
+        Long commentCount = getLongValue(obj[9]);
+
+        return new CommunitySummaryResponseDTO(
+                id, nickname, title, category, createdAt,
+                viewCount, likeCount, content, profileImageUrl, commentCount
+        );
+    }
+
+    /**
+     * Object를 Long으로 안전하게 변환하는 내부 헬퍼 메서드.
+     * Number 인스턴스인 경우 longValue()를 반환하고, null이면 null을 반환합니다.
+     * (필요에 따라 null 대신 0L을 반환하도록 수정 가능)
+     *
+     * @param numObj 변환할 객체.
+     * @return Long 값 또는 null.
+     * @throws ClassCastException Number 타입이 아닌 다른 타입이면서 null이 아닌 경우 (현재는 발생하지 않도록 처리).
+     */
+    private static Long getLongValue(Object numObj) {
+        if (numObj == null) {
+            return null; // 또는 0L (예: 조회수가 없는 경우 0으로 표시)
+        }
+        if (numObj instanceof Number) {
+            return ((Number) numObj).longValue();
+        }
+        // JPA 네이티브 쿼리가 문자열 형태로 숫자를 반환하는 경우도 드물게 있을 수 있으나,
+        // 보통 Number 타입(Integer, Long, BigInteger, BigDecimal 등)으로 반환됩니다.
+        // 여기서는 Number 타입만 처리합니다.
+        throw new IllegalArgumentException("Cannot convert to Long: Object is not a Number instance. Type: " + numObj.getClass().getName());
+    }
 }


### PR DESCRIPTION
## ✨ PR 종류

  - [x] 기능 추가
  - [x] 버그 수정
  - [x] 리팩토링
  - [ ] 문서 수정
  - [ ] 기타

## 🛠️ 작업 요약

  * **커뮤니티 게시글 목록 조회 최적화**: 주요 커뮤니티 게시글 목록 조회 API의 성능 향상을 위해 리포지토리 계층에 네이티브 SQL 쿼리를 도입하고, 게시글 본문 내용(`content`)을 지정된 길이로 요약하여 반환하도록 변경했습니다. 이를 통해 불필요한 데이터 전송량을 줄입니다.
  * **DTO 매핑 로직 개선 및 중앙화**: `Object[]` 형태의 리포지토리 조회 결과를 `CommunitySummaryResponseDTO`로 변환하는 로직을 DTO 내부의 정적 팩토리 메서드로 이전하여 코드 응집도를 높이고 서비스 계층의 책임을 명확히 했습니다.

## 📝 작업 상세

### 1\. 리포지토리 계층 (CommunityRepository )

  * 커뮤니티 게시글 목록 조회를 위한 주요 쿼리들(예: `findCommunitySummaries`, `findPopularSince`)이 기존 JPQL에서 성능 최적화를 위해 네이티브 SQL 쿼리로 전환되었습니다.
  * 이 네이티브 쿼리들은 `Object[]` 형태로 데이터를 프로젝션합니다.
  * **핵심 개선 사항**: `content` 필드는 전체 텍스트 대신, **지정된 길이(예: 75자)로 요약되고 필요한 경우 "..."이 접미사로 추가된 형태로 조회**됩니다. 이는 데이터베이스, 서버, 프론트엔드 간의 데이터 전송량을 크게 감소시킵니다.

### 2\. DTO 계층 (CommunitySummaryResponseDTO.java)

  * `Object[]`로부터 `CommunitySummaryResponseDTO` 인스턴스를 생성하는 `public static fromObjectArray(Object[] obj)` 정적 팩토리 메서드를 추가했습니다.
  * 이 메서드는 `Object[]`의 각 요소에 대한 정확한 타입 변환(예: `java.sql.Timestamp` -\> `ZonedDateTime`, `Number` -\> `Long`) 및 카테고리 문자열(`String`)의 `CommunityCategory` enum으로의 안전한 파싱 로직을 포함합니다.
  * 요약된 `content` 문자열을 그대로 DTO의 `content` 필드에 매핑합니다.

### 3\. 서비스 계층 (CommunityService.java)

  * **`findCommunities`, `findPopularCommunities` 메서드:**
      * 리포지토리로부터 **내용이 요약된** `Page<Object[]>` 또는 `List<Object[]>`를 수신합니다.
      * 수신한 `Object[]`를 `CommunitySummaryResponseDTO.fromObjectArray` 정적 팩토리 메서드를 사용하여 `CommunitySummaryResponseDTO`로 매핑합니다.
      * 이 메서드들의 최종 반환 타입은 각각 `Page<CommunitySummaryResponseDTO>`와 `List<CommunitySummaryResponseDTO>`로 유지되어, 서비스 API의 기존 계약을 변경하지 않으면서 내부적으로 최적화된 데이터 처리 및 DTO 변환을 수행합니다.
      * `findCommunities` 메서드에서는 `CommunityCategory` enum 파라미터를 네이티브 쿼리에 적합한 `String` 형태로 변환하여 리포지토리에 전달합니다.


## ✅ 체크리스트

  - [X] 코드 점검 완료 및 자체 리뷰
  - [ ] 관련 테스트 코드 작성 및 통과
  - [X] API 문서 또는 내부 주석 최신화 (변경된 반환값, 요약 로직 등)

## 📚 기타

  * 이번 변경을 통해 게시글 목록 조회 시 전송되는 데이터의 크기를 현저히 줄여, 애플리케이션의 응답 속도 개선 및 네트워크 트래픽 감소 효과를 기대합니다.
  * `content` 요약 길이는 현재 임의의 값(예: 75자)으로 설정되어 있으며, 필요시 애플리케이션 설정 또는 상수 값으로 관리하여 조절할 수 있습니다.